### PR TITLE
DotSpatial.Data: Fixed problem in ShapeReader

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,4 +12,5 @@ All notable changes to this project will be documented in this file.
 - TBD (#TaskNumber)
 
 ### Fixed
+- ShapeReader skipping one entry when switching the page (#774)
 - TBD (#TaskNumber)

--- a/Contributors
+++ b/Contributors
@@ -9,3 +9,5 @@
 # Please keep the list sorted.
 
 TBD
+
+Martin Karing <karing.martin@gmail.com>

--- a/Source/DotSpatial.Data.Tests/DotSpatial.Data.Tests.csproj
+++ b/Source/DotSpatial.Data.Tests/DotSpatial.Data.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="RasterTest.cs" />
     <Compile Include="ReadWriteTests.cs" />
     <Compile Include="ShapefileTests.cs" />
+    <Compile Include="ShapeReaderTests.cs" />
     <Compile Include="ShapeTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/DotSpatial.Data.Tests/ShapeReaderTests.cs
+++ b/Source/DotSpatial.Data.Tests/ShapeReaderTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace DotSpatial.Data.Tests
+{
+    [TestFixture]
+    class ShapeReaderTests
+    {
+        /// <summary>
+        /// This test is used to verify if the shape reader properly reads all entries in a shape file or if it skips any.
+        /// Specifically this is used to verify that moving from one page to the next works without skipping any data sets.
+        /// </summary>
+        /// <remarks>
+        /// Issue: https://dotspatial.codeplex.com/workitem/63623
+        /// </remarks>
+        [Test]
+        public void ShapeReaderSkippingTest()
+        {
+            const string path = @"Data\Shapefiles\shp-no-m\SPATIAL_F_LUFTNINGSVENTIL.shp";
+            var source = new PointShapefileShapeSource(path);
+
+            var target = new ShapeReader(source);
+            target.PageSize = 10;
+            int expectedStartIndex = 0;
+            foreach (var page in target)
+            {
+                Assert.AreEqual(expectedStartIndex, page.Keys.Min(), "Shape reader skipped at least one entry.");
+                expectedStartIndex = page.Keys.Max() + 1;
+            }
+        }
+    }
+}

--- a/Source/DotSpatial.Data/ShapeReader.cs
+++ b/Source/DotSpatial.Data/ShapeReader.cs
@@ -97,10 +97,9 @@ namespace DotSpatial.Data
             public Enumerator(ShapeReader parent)
             {
                 _source = parent._source;
-                _count = -1;
-                _index = -1;
                 _pageSize = parent.PageSize;
                 _envelope = parent.Envelope;
+                Reset();
             }
 
             #region IEnumerator<Dictionary<int,Shape>> Members
@@ -125,7 +124,6 @@ namespace DotSpatial.Data
             public bool MoveNext()
             {
                 if (_count < 0) _count = _source.GetShapeCount();
-                _index++;
                 if (_index >= _count) return false;
                 _page = _source.GetShapes(ref _index, _pageSize, _envelope);
                 return true;
@@ -135,7 +133,7 @@ namespace DotSpatial.Data
             public void Reset()
             {
                 _page = null;
-                _index = -1;
+                _index = 0;
                 _count = -1;
             }
 


### PR DESCRIPTION
Fixes #774 

Fixed the problem in the shape reader that caused it to skip a entry of
the shape file when switching from one page to the next. Also provided a
test to verify that the issue is gone.

Refs: https://dotspatial.codeplex.com/workitem/63623