### PR TITLE
Fixed the shift in x-coordinate when reprojecting from WGS84 to LAEA

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Removed obsolete methods\properties (#797)
 
 ### Fixed
+- Fixed the shift in x-coordinate when reprojecting from WGS84 to LAEA (#815)
 - Fixed LAEA reprojected y coordinate that resulted in n.def (#813)
 - ShapeReader skipping one entry when switching the page (#774)
 - DotSpatial.Projections dll file is very big (#27)

--- a/Source/DotSpatial.Projections.Tests/Projected/Europe.cs
+++ b/Source/DotSpatial.Projections.Tests/Projected/Europe.cs
@@ -36,10 +36,10 @@ namespace DotSpatial.Projections.Tests.Projected
             Reproject.ReprojectPoints(xy, z, pEnd, pStart, 0, 1);
 
             // Test X
-            Assert.AreEqual(16.4, xy[0], 0.01);
+            Assert.AreEqual(lon, xy[0], 0.00001);
 
             // Test Y
-            Assert.AreEqual(48.2, xy[1], 0.01);
+            Assert.AreEqual(lat, xy[1], 0.00001);
         }
 
         private static IEnumerable<ProjectionInfoDesc> GetProjections()

--- a/Source/DotSpatial.Projections/Transforms/LambertAzimuthalEqualArea.cs
+++ b/Source/DotSpatial.Projections/Transforms/LambertAzimuthalEqualArea.cs
@@ -329,7 +329,7 @@ namespace DotSpatial.Projections.Transforms
                     _sinb1 = Proj.Qsfn(sinphi, E, OneEs)/_qp;
                     _cosb1 = Math.Sqrt(1 - _sinb1 * _sinb1);
                     _dd = Math.Cos(Phi0) / (Math.Sqrt(1 - Es * sinphi * sinphi) * _rq * _cosb1);
-                    _ymf = _xmf = _rq / _dd;
+                    _ymf = (_xmf = _rq) / _dd;
                     _xmf *= _dd;
                     break;
             }


### PR DESCRIPTION
Fixes #815 .

Fixed the shift in x-coordinate when reprojecting from WGS84 to ETRS89 LAEA.