### PR TITLE
Added support for Shapefiles to be opened in memory

### DIFF
--- a/Source/DotSpatial.Data/AttributeTable.cs
+++ b/Source/DotSpatial.Data/AttributeTable.cs
@@ -718,6 +718,8 @@ namespace DotSpatial.Data
         /// <summary>
         /// Reads the header and if deletedRows is null, searches file for deletedRows if file size indicates possibility of deleted rows.
         /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="deletedRows"></param>
         public void Open(string fileName, List<int> deletedRows)
         {
             Contract.Requires(!String.IsNullOrEmpty(fileName), "fileName is null or empty.");
@@ -893,7 +895,7 @@ namespace DotSpatial.Data
         /// This populates the Table with data from the file.
         /// </summary>
         /// <param name="numRows">In the event that the dbf file is not found, this indicates how many blank rows should exist in the attribute Table.</param>
-        public void Fill(int numRows)
+        public void Fill(int numRows) 
         {
             if (_isFilling) return; // Changed by jany_ (2015-07-30) don't load again because the fill methode is called from inside the fill methode and we'd get a datatable that is filled with twice the existing records
             _attributesPopulated = false;
@@ -2001,7 +2003,7 @@ namespace DotSpatial.Data
         {
             get
             {
-                if (!_attributesPopulated)
+                if (!_attributesPopulated && (!string.IsNullOrEmpty(Filename) || _dbaseBytes != null))
                     Fill(_numRecords);
                 return _dataTable;
             }

--- a/Source/DotSpatial.Data/AttributeTable.cs
+++ b/Source/DotSpatial.Data/AttributeTable.cs
@@ -64,6 +64,7 @@ namespace DotSpatial.Data
         private Encoding _encoding;
         private DateTime _updateDate;
         private BinaryWriter _writer;
+        private Byte[] _dbaseBytes;
         /// <summary>
         /// Indicates that the Fill methode is called from inside itself.
         /// </summary>
@@ -717,8 +718,6 @@ namespace DotSpatial.Data
         /// <summary>
         /// Reads the header and if deletedRows is null, searches file for deletedRows if file size indicates possibility of deleted rows.
         /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="deletedRows"></param>
         public void Open(string fileName, List<int> deletedRows)
         {
             Contract.Requires(!String.IsNullOrEmpty(fileName), "fileName is null or empty.");
@@ -774,37 +773,109 @@ namespace DotSpatial.Data
             }
         }
 
+        /// <summary>
+        /// Reads all the information from the file, including the vector shapes and the database component.
+        /// </summary>
+        public void Open(Byte[] b)
+        {
+            Open(b, null);
+        }
+
+        /// <summary>
+        /// Reads the header and if deletedRows is null, searches file for deletedRows if file size indicates possibility of deleted rows.
+        /// </summary>
+        public void Open(Byte[] b, List<int> deletedRows)
+        {
+            _dbaseBytes = b;
+            _attributesPopulated = false; // we had a file, but have not read the dbf content into memory yet.
+            _dataTable = new DataTable();
+
+            using (var reader = new BinaryReader(new MemoryStream(_dbaseBytes)))
+            {
+                ReadTableHeader(reader); // based on the header, set up the fields information etc.
+
+                // If the deleted rows were passed in, we don't need to look for them
+                if (null != deletedRows)
+                {
+                    _deletedRows = deletedRows;
+                    _hasDeletedRecords = _deletedRows.Count > 0;
+                    return;
+                }
+                long length = _headerLength + _numRecords * _recordLength;
+                long pos = reader.BaseStream.Position;
+                if (HasEof(reader.BaseStream, length))
+                    length++;
+
+                if (b.Length == length)
+                {
+                    _hasDeletedRecords = false;
+                    // No deleted rows detected
+                    return;
+                }
+
+                reader.BaseStream.Seek(pos, SeekOrigin.Begin);
+
+                _hasDeletedRecords = true;
+                int count = 0;
+                int row = 0;
+                while (count < _numRecords)
+                {
+                    if (reader.BaseStream.ReadByte() == (byte)' ')
+                    {
+                        count++;
+                    }
+                    else
+                    {
+                        _deletedRows.Add(row);
+                    }
+                    row++;
+                    reader.BaseStream.Seek(_recordLength - 1, SeekOrigin.Current);
+                }
+            }
+        }
+
         private void GetRowOffsets()
         {
-            var fi = new FileInfo(_fileName);
-
-            // Encoding appears to be ASCII, not Unicode
-            if ((int)fi.Length == _headerLength)
+            if (_fileName != null)
             {
-                // The file is empty, so we are done here
-                return;
-            }
+                var fi = new FileInfo(_fileName);
 
-            if (_hasDeletedRecords)
-            {
-                int length = (int)(fi.Length - _headerLength - 1);
-                int recordCount = length / _recordLength;
-                _offsets = new long[_numRecords];
-                int j = 0; // undeleted index
-                using (var myReader = GetBinaryReader())
+                // Encoding appears to be ASCII, not Unicode
+                if ((int)fi.Length == _headerLength)
                 {
-                    for (int i = 0; i <= recordCount; i++)
+                    // The file is empty, so we are done here
+                    return;
+                }
+                if (_hasDeletedRecords)
+                {
+                    int length = (int)(fi.Length - _headerLength - 1);
+                    int recordCount = length / _recordLength;
+                    _offsets = new long[_numRecords];
+                    int j = 0; // undeleted index
+                    using (var myReader = GetBinaryReader())
                     {
-                        // seek to byte
-                        myReader.BaseStream.Seek(_headerLength + 1 + i * _recordLength, SeekOrigin.Begin);
-                        var cb = myReader.ReadByte();
-                        if (cb != '*')
-                            _offsets[j] = i * _recordLength;
-                        j++;
-                        if (j == _numRecords) break;
+                        for (int i = 0; i <= recordCount; i++)
+                        {
+                            // seek to byte
+                            myReader.BaseStream.Seek(_headerLength + 1 + i * _recordLength, SeekOrigin.Begin);
+                            var cb = myReader.ReadByte();
+                            if (cb != '*')
+                                _offsets[j] = i * _recordLength;
+                            j++;
+                            if (j == _numRecords) break;
+                        }
                     }
                 }
             }
+
+            if (_dbaseBytes != null)
+            {
+                if (_dbaseBytes.Length == _headerLength)
+                {
+                    return;
+                }
+            }
+
             _loaded = true;
         }
 
@@ -828,7 +899,7 @@ namespace DotSpatial.Data
             _attributesPopulated = false;
             _dataTable.Rows.Clear(); // if we have already loaded data, clear the data.
             _isFilling = true;
-            if (!File.Exists(_fileName))
+            if (!File.Exists(_fileName) && _dbaseBytes == null)
             {
                 _numRecords = numRows;
                 _dataTable.BeginLoadData();
@@ -855,7 +926,7 @@ namespace DotSpatial.Data
 
             _dataTable.BeginLoadData();
             // Reading the Table elements as well as the shapes in a single progress loop.
-            using (var myReader = GetBinaryReader())
+            using (var myReader = _dbaseBytes != null ? new BinaryReader(new MemoryStream(_dbaseBytes)) : GetBinaryReader())
             {
                 for (int row = 0; row < _numRecords; row++)
                 {
@@ -1930,7 +2001,7 @@ namespace DotSpatial.Data
         {
             get
             {
-                if (!_attributesPopulated && !string.IsNullOrEmpty(Filename))
+                if (!_attributesPopulated)
                     Fill(_numRecords);
                 return _dataTable;
             }

--- a/Source/DotSpatial.Data/FeatureSet.cs
+++ b/Source/DotSpatial.Data/FeatureSet.cs
@@ -24,12 +24,12 @@ using NetTopologySuite.Geometries;
 
 namespace DotSpatial.Data
 {
-    /// <summary>
-    /// Rather than being an abstract base class, this is a "router" class that will
-    /// make decisions based on the file extension or whatever being used and decide the best
-    /// IFeatureSet that matches the specifications.
-    /// </summary>
-    public class FeatureSet : DataSet, IFeatureSet
+   /// <summary>
+   /// Rather than being an abstract base class, this is a "router" class that will
+   /// make decisions based on the file extension or whatever being used and decide the best
+   /// IFeatureSet that matches the specifications.
+   /// </summary>
+   public class FeatureSet : DataSet, IFeatureSet
     {
         #region Events
 
@@ -1768,7 +1768,7 @@ namespace DotSpatial.Data
 
                 foreach (IFeature feature in Features)
                 {
-                    feature.Geometry.GeometryChanged();
+                    feature.Geometry.UpdateEnvelope();
                     MyExtent.ExpandToInclude(new Extent(feature.Geometry.EnvelopeInternal));
                 }
             }

--- a/Source/DotSpatial.Data/PolygonShapefile.cs
+++ b/Source/DotSpatial.Data/PolygonShapefile.cs
@@ -80,6 +80,39 @@ namespace DotSpatial.Data
             ReadProjection();
         }
 
+        /// <summary>
+        /// Opens a shapefile
+        /// </summary>
+        /// <param name="shapeBytes">The shape bytes</param>
+        /// <param name="indexBytes">The index bytes</param>
+        /// <param name="dbaseBytes">The dbase bytes</param>
+        /// <param name="projectionBytes">The projection bytes</param>
+        /// <param name="progressHandler">Any valid implementation of the DotSpatial.Data.IProgressHandler</param>
+        public void Open(Byte[] shapeBytes, Byte[] indexBytes, Byte[] dbaseBytes, Byte[] projectionBytes, IProgressHandler progressHandler)
+        {
+            IndexMode = true;
+            Header = new ShapefileHeader(shapeBytes);
+
+            switch (Header.ShapeType)
+            {
+                case ShapeType.PolyLineM:
+                    CoordinateType = CoordinateType.M;
+                    break;
+                case ShapeType.PolyLineZ:
+                    CoordinateType = CoordinateType.Z;
+                    break;
+                default:
+                    CoordinateType = CoordinateType.Regular;
+                    break;
+            }
+
+            Extent = Header.ToExtent();
+            Attributes.Open(dbaseBytes);
+
+            LineShapefile.FillLines(shapeBytes, indexBytes, progressHandler, this, FeatureType.Line);
+            ReadProjection(projectionBytes);
+        }
+
         // X Y Poly Lines: Total Length = 28 Bytes
         // ---------------------------------------------------------
         // Position     Value               Type        Number      Byte Order

--- a/Source/DotSpatial.Data/ShapefileHeader.cs
+++ b/Source/DotSpatial.Data/ShapefileHeader.cs
@@ -71,6 +71,14 @@ namespace DotSpatial.Data
             Open(inFilename);
         }
 
+        /// <summary>
+        /// Opens the specified shape file directly
+        /// </summary>
+        /// <param name="b">The header bytes.</param>
+        public ShapefileHeader(Byte[] b)
+        {
+            Open(b);
+        }
         #endregion
 
         #region Methods
@@ -88,7 +96,7 @@ namespace DotSpatial.Data
             _yMax = 0.0;
             _zMin = 0.0;
             _zMax = 0.0;
-            _mMin = 0.0;
+            _mMin = 0.0; 
             _mMax = 0.0;
         }
 
@@ -100,67 +108,22 @@ namespace DotSpatial.Data
         {
             Filename = inFilename;
 
-            //  Position        Field           Value       Type        ByteOrder
-            //  --------------------------------------------------------------
-            //  Byte 0          File Code       9994        Integer     Big
-            //  Byte 4          Unused          0           Integer     Big
-            //  Byte 8          Unused          0           Integer     Big
-            //  Byte 12         Unused          0           Integer     Big
-            //  Byte 16         Unused          0           Integer     Big
-            //  Byte 20         Unused          0           Integer     Big
-            //  Byte 24         File Length     File Length Integer     Big
-            //  Byte 28         Version         1000        Integer     Little
-            //  Byte 32         Shape Type      Shape Type  Integer     Little
-            //  Byte 36         Bounding Box    Xmin        Double      Little
-            //  Byte 44         Bounding Box    Ymin        Double      Little
-            //  Byte 52         Bounding Box    Xmax        Double      Little
-            //  Byte 60         Bounding Box    Ymax        Double      Little
-            //  Byte 68         Bounding Box    Zmin        Double      Little
-            //  Byte 76         Bounding Box    Zmax        Double      Little
-            //  Byte 84         Bounding Box    Mmin        Double      Little
-            //  Byte 92         Bounding Box    Mmax        Double      Little
-
             // This may throw an IOException if the file is already in use.
             BufferedBinaryReader bbReader = new BufferedBinaryReader(Filename);
 
-            bbReader.FillBuffer(100); // we only need to read 100 bytes from the header.
-
-            bbReader.Close(); // Close the internal readers connected to the file, but don't close the file itself.
-
-            // Reading BigEndian simply requires us to reverse the byte order.
-            _fileCode = bbReader.ReadInt32(false);
-
-            // Skip the next 20 bytes because they are unused
-            bbReader.Seek(20, SeekOrigin.Current);
-
-            // Read the file length in reverse sequence
-            _fileLength = bbReader.ReadInt32(false);
-
-            // From this point on, all the header values are in little Endean
-
-            // Read the version
-            _version = bbReader.ReadInt32();
-
-            // Read in the shape type that should be the shape type for the whole shapefile
-            _shapeType = (ShapeType)bbReader.ReadInt32();
-
-            // Get the extents, each of which are double values.
-            _xMin = bbReader.ReadDouble();
-            _yMin = bbReader.ReadDouble();
-            _xMax = bbReader.ReadDouble();
-            _yMax = bbReader.ReadDouble();
-            _zMin = bbReader.ReadDouble();
-            _zMax = bbReader.ReadDouble();
-            _mMin = bbReader.ReadDouble();
-            _mMax = bbReader.ReadDouble();
-
-            bbReader.Dispose();
+            Open(bbReader);
 
             FileInfo fi = new FileInfo(ShxFilename);
             if (fi.Exists)
             {
                 _shxLength = Convert.ToInt32(fi.Length / 2); //length is in 16 bit words.
             }
+        }
+
+        public void Open(Byte[] b)
+        {
+            BufferedBinaryReader bbReader = new BufferedBinaryReader(b);
+            Open(bbReader);
         }
 
         /// <summary>
@@ -492,6 +455,63 @@ namespace DotSpatial.Data
             _xMax = extent.MaxX;
             _yMin = extent.MinY;
             _yMax = extent.MaxY;
+        }
+
+        private void Open(BufferedBinaryReader bbReader)
+        {
+            //  Position        Field           Value       Type        ByteOrder
+            //  --------------------------------------------------------------
+            //  Byte 0          File Code       9994        Integer     Big
+            //  Byte 4          Unused          0           Integer     Big
+            //  Byte 8          Unused          0           Integer     Big
+            //  Byte 12         Unused          0           Integer     Big
+            //  Byte 16         Unused          0           Integer     Big
+            //  Byte 20         Unused          0           Integer     Big
+            //  Byte 24         File Length     File Length Integer     Big
+            //  Byte 28         Version         1000        Integer     Little
+            //  Byte 32         Shape Type      Shape Type  Integer     Little
+            //  Byte 36         Bounding Box    Xmin        Double      Little
+            //  Byte 44         Bounding Box    Ymin        Double      Little
+            //  Byte 52         Bounding Box    Xmax        Double      Little
+            //  Byte 60         Bounding Box    Ymax        Double      Little
+            //  Byte 68         Bounding Box    Zmin        Double      Little
+            //  Byte 76         Bounding Box    Zmax        Double      Little
+            //  Byte 84         Bounding Box    Mmin        Double      Little
+            //  Byte 92         Bounding Box    Mmax        Double      Little
+
+            // This may throw an IOException if the file is already in use.
+            bbReader.FillBuffer(100); // we only need to read 100 bytes from the header.
+
+            bbReader.Close(); // Close the internal readers connected to the file, but don't close the file itself.
+
+            // Reading BigEndian simply requires us to reverse the byte order.
+            _fileCode = bbReader.ReadInt32(false);
+
+            // Skip the next 20 bytes because they are unused
+            bbReader.Seek(20, SeekOrigin.Current);
+
+            // Read the file length in reverse sequence
+            _fileLength = bbReader.ReadInt32(false);
+
+            // From this point on, all the header values are in little Endean
+
+            // Read the version
+            _version = bbReader.ReadInt32();
+
+            // Read in the shape type that should be the shape type for the whole shapefile
+            _shapeType = (ShapeType)bbReader.ReadInt32();
+
+            // Get the extents, each of which are double values.
+            _xMin = bbReader.ReadDouble();
+            _yMin = bbReader.ReadDouble();
+            _xMax = bbReader.ReadDouble();
+            _yMax = bbReader.ReadDouble();
+            _zMin = bbReader.ReadDouble();
+            _zMax = bbReader.ReadDouble();
+            _mMin = bbReader.ReadDouble();
+            _mMax = bbReader.ReadDouble();
+
+            bbReader.Dispose();
         }
     }
 }


### PR DESCRIPTION
An override to the Open method has been created.
The new signature expects binary arrays for the .shp, .shx, .dbf, and .prj.

Example usage...
var shapeBytes = File.ReadAllBytes($"{dir}\{filename}.shp");
var indexBytes = File.ReadAllBytes($"{dir}\{filename}.shx");
var dbaseBytes = File.ReadAllBytes($"{dir}\{filename}.dbf");
var projectionBytes = File.ReadAllBytes($"{dir}\{filename}.prj");
Shapefile.OpenFile(shapeBytes, indexBytes, dbaseBytes, projectionBytes);

Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-