### PR TITLE
Support for serial gps devices on mono.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -118,3 +118,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Legend drag line so it doesn't look as if you can move a layer in between categories (#1008)
 - Legend selection to be able to select features of a category (#1008)
 - Some errors in SetSelectable plugin (#1008)
+- Crash when attempting to use a serial GPS device on Mono

--- a/Contributors
+++ b/Contributors
@@ -49,3 +49,4 @@ Teva Veluppillai
 Peder Wikstrom <peder.wikstrom@treesys.se>
 Chris Wilson
 Ping Yang
+Trent Muhr

--- a/Source/DotSpatial.Positioning.Compact/GPS/Devices/SerialPort.cs
+++ b/Source/DotSpatial.Positioning.Compact/GPS/Devices/SerialPort.cs
@@ -30,6 +30,7 @@ namespace DotSpatial.Positioning.Gps.IO
 #endif
 
         private StreamReader _Reader;
+        private bool onMono = Type.GetType("Mono.Runtime") != null;
 
         #region Constructors
 
@@ -59,7 +60,8 @@ namespace DotSpatial.Positioning.Gps.IO
             NewLine = "\r\n";
             WriteBufferSize = NmeaReader.IdealNmeaBufferSize;
             ReadBufferSize = NmeaReader.IdealNmeaBufferSize; 
-            ReceivedBytesThreshold = 65535;  // We don't need this event, so max out the threshold
+            if (!onMono) // ReceivedBytesThreshold is not implemented on mono, thus throwing an exception.
+                ReceivedBytesThreshold = 65535;  // We don't need this event, so max out the threshold
             Encoding = Encoding.ASCII;
         }
 #endif

--- a/Source/DotSpatial.Positioning/SerialPort.cs
+++ b/Source/DotSpatial.Positioning/SerialPort.cs
@@ -48,6 +48,7 @@ namespace DotSpatial.Positioning
         ///
         /// </summary>
         private StreamReader _reader;
+        private bool onMono = Type.GetType("Mono.Runtime") != null;
 
         #region Constructors
 
@@ -97,7 +98,8 @@ namespace DotSpatial.Positioning
             NewLine = "\r\n";
             WriteBufferSize = NmeaReader.IDEAL_NMEA_BUFFER_SIZE;
             ReadBufferSize = NmeaReader.IDEAL_NMEA_BUFFER_SIZE;
-            ReceivedBytesThreshold = 65535;  // We don't need this event, so max out the threshold
+            if (!onMono) // ReceivedBytesThreshold is not implemented on mono, thus throwing an exception.
+                ReceivedBytesThreshold = 65535;  // We don't need this event, so max out the threshold
             Encoding = Encoding.ASCII;
         }
 


### PR DESCRIPTION
ReceivedBytesThreshold is not implemented on mono, and throws an exception when the constructor attempts to set it. This detects if mono is being used according to [http://www.mono-project.com/docs/faq/technical/](url) and, if so, avoids setting the property.