### PR TITLE
GeometryCollection Feature type to check its first Item for the Featu…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -126,3 +126,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Crash when attempting to use a serial GPS device on Mono
 - Clear the selection inside FeatureLayer.RemoveSelectedFeatures so the removed features are no longer contained when IFeatureSet.FeatureRemoved is raised
 - In InRamImageData.Open don't draw the image unscaled because this can cause the image not to be drawn
+- FeatureTypeFromGeometryType Method updated to work with GeometryCollection

--- a/Contributors
+++ b/Contributors
@@ -50,3 +50,4 @@ Peder Wikstrom <peder.wikstrom@treesys.se>
 Chris Wilson
 Ping Yang
 Trent Muhr
+Joe Houghton

--- a/Source/DotSpatial.Data/Feature.cs
+++ b/Source/DotSpatial.Data/Feature.cs
@@ -456,8 +456,24 @@ namespace DotSpatial.Data
                     IGeometryCollection geomCollection = geometry as IGeometryCollection;
                     if (geomCollection != null)
                     {
-                        if (geomCollection.NumGeometries > 0)
-                            featureType = FeatureTypeFromGeometryType(geomCollection[0]);
+                        // Check to see if every featureType in the GeometryCollection matches
+                        // else leave as FeatureType.Unspecified
+                        FeatureType testFeatureType = FeatureType.Unspecified;
+                        for (int i = 0; i < geomCollection.Count; i++)
+                        {
+                            if (i == 0)
+                            {
+                                testFeatureType = FeatureTypeFromGeometryType(geomCollection[i]);
+                            }
+                            else
+                            {
+                                FeatureType tempFeatureType = FeatureTypeFromGeometryType(geomCollection[i]);
+                                if (testFeatureType != tempFeatureType)
+                                    return FeatureType.Unspecified; // if feature types do not match, then return Unspecified
+                            }
+                        }
+
+                        featureType = testFeatureType;
                     }
 
                     break;

--- a/Source/DotSpatial.Data/Feature.cs
+++ b/Source/DotSpatial.Data/Feature.cs
@@ -249,7 +249,7 @@ namespace DotSpatial.Data
                 {
                     return ShapeIndex?.RecordNumber - 1 ?? -2; // -1 because RecordNumber for shapefiles is 1-based.
 
-                    // todo: The better will be remove RecordNumber from public interface to avoid ±1 issues.
+                    // todo: The better will be remove RecordNumber from public interface to avoid Â±1 issues.
                 }
 
                 return _parentFeatureSet.Features.IndexOf(this);
@@ -451,6 +451,15 @@ namespace DotSpatial.Data
                     break;
                 case OgcGeometryType.MultiPoint:
                     featureType = FeatureType.MultiPoint;
+                    break;
+                case OgcGeometryType.GeometryCollection:
+                    IGeometryCollection geomCollection = geometry as IGeometryCollection;
+                    if (geomCollection != null)
+                    {
+                        if (geomCollection.NumGeometries > 0)
+                            featureType = FeatureTypeFromGeometryType(geomCollection[0]);
+                    }
+
                     break;
             }
 


### PR DESCRIPTION
When creating a Feature using a GeometryCollection there is no other way to set the FeatureType, meaning that it cannot be written out to file as the FeatureType is Unspecified by default.
This alteration gets the FeatureType of the first Item in the GeometryCollection.
