### PR TITLE
Plugins/WFSClient: Feature fetching fails on systems w NumberFormatIn…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -136,3 +136,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - FeatureTypeFromGeometryType Method updated to work with GeometryCollection (#1044)
 - The SpatiaLite plugin to be able to load SpatiaLite databases of version 4 and higher (#1061)
 - WebMap-Plugin fails fetching tiles for specific WMS (#1074)
+- Plugins/WFSClient: Feature fetching fails on systems w NumberFormatInfo.NumberDecimalSeparator != '.' (#1081)

--- a/Contributors
+++ b/Contributors
@@ -51,3 +51,4 @@ Chris Wilson
 Ping Yang
 Trent Muhr
 Joe Houghton
+Matthias Schider <matthias.schilder1@gmail.com>

--- a/Source/DotSpatial.Plugins.WFSClient/Classes/WFSClient.cs
+++ b/Source/DotSpatial.Plugins.WFSClient/Classes/WFSClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -294,7 +295,11 @@ namespace DotSpatial.Plugins.WFSClient.Classes
             List<Coordinate> lstCoor = new List<Coordinate>();
 
             for (int i = 0; i < listpoints.Length; i = i + 2)
-                lstCoor.Add(new Coordinate(Convert.ToDouble(listpoints[i]), Convert.ToDouble(listpoints[i + 1])));
+            {
+                lstCoor.Add(new Coordinate(
+                    Convert.ToDouble(listpoints[i], CultureInfo.InvariantCulture), 
+                    Convert.ToDouble(listpoints[i + 1], CultureInfo.InvariantCulture)));
+            }
 
             return lstCoor.ToArray();
         }
@@ -451,7 +456,9 @@ namespace DotSpatial.Plugins.WFSClient.Classes
 
                 string point = Convert.ToString(geoData);
                 var pointValue = point.Split(' ');
-                geo = new Point(Convert.ToDouble(pointValue[0]), Convert.ToDouble(pointValue[1]));
+                geo = new Point(
+                    Convert.ToDouble(pointValue[0], CultureInfo.InvariantCulture),
+                    Convert.ToDouble(pointValue[1], CultureInfo.InvariantCulture));
             }
 
             if (_typeGeometry == FeatureType.Polygon)


### PR DESCRIPTION
Fixes # 1081.
Plugins/WFSClient: Feature fetching fails on systems w NumberFormatInfo.NumberDecimalSeparator != '.' 

### Checklist

- [x] I have included examples or tests (bug repro)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)
