### PR TITLE
Fix V3005

### DIFF
--- a/Source/DotSpatial.Data/BinaryRaster.cs
+++ b/Source/DotSpatial.Data/BinaryRaster.cs
@@ -421,7 +421,7 @@ namespace DotSpatial.Data
             StartColumn = startColumn;
             StartRow = startRow;
             EndColumn = endColumn;
-            EndRow = EndRow;
+            EndRow = endRow;
 
             // Reposition the "raster" so that it matches the window, not the whole raster
             Bounds.AffineCoefficients = new AffineTransform(Bounds.AffineCoefficients).TransfromToCorner(startColumn, startRow);


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

-The 'EndRow' variable is assigned to itself. DotSpatial.Data BinaryRaster.cs 424