### PR TITLE
Fix V3008

### DIFF
--- a/Source/DotSpatial.Projections/GeographicCategories/World.cs
+++ b/Source/DotSpatial.Projections/GeographicCategories/World.cs
@@ -88,7 +88,7 @@ namespace DotSpatial.Projections.GeographicCategories
 
             ITRF1997 = ProjectionInfo.FromProj4String("+proj=longlat +ellps=GRS80 +no_defs ");
             ITRF1997.GeographicInfo.Name = "GCS_ITRF_1997";
-            ITRF1997.GeographicInfo.Name = "D_ITRF_1997";
+            ITRF1997.GeographicInfo.Datum.Name = "D_ITRF_1997";
 
             ITRF2000 = ProjectionInfo.FromProj4String("+proj=longlat +ellps=GRS80 +no_defs ");
             ITRF2000.GeographicInfo.Name = "GCS_ITRF_2000";


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- The 'ITRF1997.GeographicInfo.Name' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 91, 90. DotSpatial.Projections World.cs 91