### PR TITLE
Fix V3029

### DIFF
--- a/Source/DotSpatial.Controls/LayoutMenuStrip.cs
+++ b/Source/DotSpatial.Controls/LayoutMenuStrip.cs
@@ -54,7 +54,7 @@ namespace DotSpatial.Controls
                 _layoutControl = value;
 
                 // Sets the Margin tool to checked depending on the property of the layoutcontrol
-                if (_layoutControl.LayoutZoomToolStrip != null)
+                if (_layoutControl != null)
                 {
                     _showMargin.Checked = _layoutControl.ShowMargin;
                 }


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

* The conditional expressions of the 'if' statements situated alongside each other are identical. Check lines: 57, 63. DotSpatial.Controls LayoutMenuStrip.cs 57