### PR TITLE
Error on OpenFile with special SPHEROID string (#1142)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -145,3 +145,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - assign "D_ITRF_1997" to ITRF1997.GeographicInfo.Datum.Name instead of ITRF1997.GeographicInfo.Name because this is the name of the datum and not the GeographicInfo (#1090)
 - Update Brutile version in Webmap? (#800)
 - SetSelectable Plugin Not Included in Release Build (#1106)
+- Error on OpenFile with special SPHEROID string (#1142)

--- a/Source/DotSpatial.Projections.Tests/DotSpatial.Projections.Tests.csproj
+++ b/Source/DotSpatial.Projections.Tests/DotSpatial.Projections.Tests.csproj
@@ -168,6 +168,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="ReprojectTests.cs" />
+    <Compile Include="SpheroidTests.cs" />
     <Compile Include="Tester.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/DotSpatial.Projections.Tests/SpheroidTests.cs
+++ b/Source/DotSpatial.Projections.Tests/SpheroidTests.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+
+namespace DotSpatial.Projections.Tests
+{
+    [TestFixture]
+    class SpheroidTests
+    {
+        /// <summary>
+        /// Checks that parsing an ESRI string with [ and ] in the spheroid name gets the complete name and doesn't throw an exception.
+        /// </summary>
+        [Test(Description = @"Checks that parsing an ESRI string with [ and ] in the spheroid name gets the complete name and doesn't throw an exception. (https://github.com/DotSpatial/DotSpatial/issues/1142)")]
+        public void ParseEsriStringWithBracketInSpheroidName()
+        {
+            Spheroid s = new Spheroid();
+            Assert.DoesNotThrow(() => s.ParseEsriString("GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984[EPSG ID 7030]\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.017453292519943295]]"));
+            Assert.AreEqual("WGS_1984[EPSG ID 7030]", s.Name, "The Spheroid name does not equal WGS_1984[EPSG ID 7030].");
+        }
+
+        /// <summary>
+        /// Checks that parsing an ESRI string without [ and ] in the spheroid name gets the complete name and doesn't throw an exception.
+        /// </summary>
+        [Test(Description = @"Checks that parsing an ESRI string without [ and ] in the spheroid name gets the complete name and doesn't throw an exception. (https://github.com/DotSpatial/DotSpatial/issues/1142)")]
+        public void ParseEsriStringWithoutBracketInSpheroidName()
+        {
+            Spheroid s = new Spheroid();
+            Assert.DoesNotThrow(() => s.ParseEsriString("GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.017453292519943295]]"));
+            Assert.AreEqual("WGS_1984", s.Name, "The Spheroid name does not equal WGS_1984.");
+        }
+    }
+}

--- a/Source/DotSpatial.Projections/Spheroid.cs
+++ b/Source/DotSpatial.Projections/Spheroid.cs
@@ -625,9 +625,27 @@ namespace DotSpatial.Projections
         /// <param name="esriString"></param>
         public void ParseEsriString(string esriString)
         {
-            if (esriString.Contains("SPHEROID") == false) return;
+            if (!esriString.Contains("SPHEROID"))
+                return;
+                
             int iStart = esriString.IndexOf("SPHEROID", StringComparison.Ordinal) + 9;
-            int iEnd = esriString.IndexOf("]", iStart, StringComparison.Ordinal);
+            int iEnd = iStart;
+            int numLeftBrackets = 0, numRightBrackets = 0;
+            for (int i = iStart; i < esriString.Length; i++)
+            {
+                char c = esriString[i];
+                if (c == '[')
+                    numLeftBrackets++;
+                else if (c == ']')
+                {
+                    numRightBrackets++;
+                    if (numRightBrackets <= numLeftBrackets) continue;
+
+                    iEnd = i;
+                    break;
+                }
+            }
+
             if (iEnd < iStart) return;
             string extracted = esriString.Substring(iStart, iEnd - iStart);
             string[] terms = extracted.Split(',');

--- a/Source/DotSpatial.Projections/Spheroid.cs
+++ b/Source/DotSpatial.Projections/Spheroid.cs
@@ -302,7 +302,7 @@ namespace DotSpatial.Projections
                     _equatorialRadius = 6375738.7;
                     InverseFlattening = 334.29;
                     break;
-                case Proj4Ellipsoid.Custom: 
+                case Proj4Ellipsoid.Custom:
                     // Nothing for Custom
                     break;
                 case Proj4Ellipsoid.Delambre_1810:
@@ -627,22 +627,27 @@ namespace DotSpatial.Projections
         {
             if (!esriString.Contains("SPHEROID"))
                 return;
-                
+
             int iStart = esriString.IndexOf("SPHEROID", StringComparison.Ordinal) + 9;
-            int iEnd = iStart;
-            int numLeftBrackets = 0, numRightBrackets = 0;
+            int iEnd = 0;
+            int numLeftBrackets = 0;
+            int numRightBrackets = 0;
+
             for (int i = iStart; i < esriString.Length; i++)
             {
                 char c = esriString[i];
                 if (c == '[')
+                {
                     numLeftBrackets++;
+                }
                 else if (c == ']')
                 {
                     numRightBrackets++;
-                    if (numRightBrackets <= numLeftBrackets) continue;
-
-                    iEnd = i;
-                    break;
+                    if (numRightBrackets > numLeftBrackets)
+                    {
+                        iEnd = i;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes # 1142.

Test data:
[1142.zip](https://github.com/DotSpatial/DotSpatial/files/1819939/1142.zip)

(contains a shapefile with ESRI WKT GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984 [EPSG ID 7030]",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]])

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- fixes #1142 