### PR TITLE
Natural breaks tidy up

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -149,3 +149,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Shape File Saves with Wrong DataTypes (#1005)
 - Calculation of translation param in InRamImageData.GetBitmap is defective (#1203)
 - MapImageLayer not drawn correctly on print (#1137)
+- Create Categories for symbology is inconsistent with large datasets (#1242)

--- a/Contributors
+++ b/Contributors
@@ -16,7 +16,7 @@ Jany
 Maxim Miroshnikov <mogikanin.tir@gmail.com>
 
 Contributors:
-Dan Ames
+Dan Ames <dan.ames@byu.edu>
 Darrel Brown
 Yang Cao
 Hugo Dejaune <hugo.dejaune@gmail.com>

--- a/Source/DotSpatial.Symbology/FeatureScheme.cs
+++ b/Source/DotSpatial.Symbology/FeatureScheme.cs
@@ -301,7 +301,8 @@ namespace DotSpatial.Symbology
                 pageSize = 10000;
                 int count = EditorSettings.MaxSampleCount;
 
-                Random rnd = new Random();
+                // Specified seed is required for consistently recreating the break values
+                Random rnd = new Random(9999);
                 AttributePager ap = new AttributePager(source, pageSize);
                 int countPerPage = count / ap.NumPages();
                 ProgressMeter pm = new ProgressMeter(progressHandler, "Sampling " + count + " random values", count);
@@ -385,7 +386,10 @@ namespace DotSpatial.Symbology
                         Dictionary<int, double> randomValues = new Dictionary<int, double>();
                         int count = EditorSettings.MaxSampleCount;
                         int max = rows.Length;
-                        Random rnd = new Random();
+
+                        // Specified seed is required for consistently recreating the break values
+                        Random rnd = new Random(9999);
+
                         for (int i = 0; i < count; i++)
                         {
                             double val;
@@ -448,7 +452,9 @@ namespace DotSpatial.Symbology
                 Dictionary<int, double> randomValues = new Dictionary<int, double>();
                 int count = EditorSettings.MaxSampleCount;
                 int max = table.Rows.Count;
-                Random rnd = new Random();
+
+                // Specified seed is required for consistently recreating the break values
+                Random rnd = new Random(9999);
                 for (int i = 0; i < count; i++)
                 {
                     double val;

--- a/Source/DotSpatial.Symbology/NaturalBreaks.cs
+++ b/Source/DotSpatial.Symbology/NaturalBreaks.cs
@@ -91,7 +91,7 @@ namespace DotSpatial.Symbology
                 _lowerClassLimits[1, i] = 1;
                 _varianceCombinations[1, i] = 0;
 
-                // in the original implementation, 9999999 is used but since Javascript has `Infinity`, we use that.
+                // in the original implementation, 9999999 is used but since C# has `PositiveInfinity`, we use that.
                 for (j = 2; j < _values.Length + 1; j++)
                 {
                     _varianceCombinations[j, i] = double.PositiveInfinity;


### PR DESCRIPTION
Fixes # No issue associated with this.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Simple update to the FeatureScheme.cs to consistently recreate break values. This only affects symbology when computing breaks on very large data sets. In this case a random subsample of the data is used for the break calculation. This is unnerving to the end users when they see the break values change slightly each time they are recomputed. Using a common random seed here means that the same subsample will be used each time the same dataset is symbolized.
-
-
-