### PR TITLE
Labeler Crash with Mercator or Orthographic projection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -150,3 +150,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Calculation of translation param in InRamImageData.GetBitmap is defective (#1203)
 - MapImageLayer not drawn correctly on print (#1137)
 - Create Categories for symbology is inconsistent with large datasets (#1242)
+- Labels with Null coordinates cause an exception

--- a/Contributors
+++ b/Contributors
@@ -54,3 +54,4 @@ Joe Houghton
 Matthias Schider <matthias.schilder1@gmail.com>
 Ilya Sosnovsky <yakrewedko@ya.ru>
 Bryan Price <southernprogrammer@gmail.com>
+Abel G. Perez <sindizzy@gmail.com>

--- a/Source/DotSpatial.Controls.Tests/TestFiles/FeatureLabelsWithNanCoords.dspx
+++ b/Source/DotSpatial.Controls.Tests/TestFiles/FeatureLabelsWithNanCoords.dspx
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-16"?>
+<root type="0">
+  <types>
+    <item key="0" value="System.Object[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="1" value="System.String[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="2" value="DotSpatial.Controls.Map, DotSpatial.Controls, Version=2.0.0.443, Culture=neutral, PublicKeyToken=4d9e49339a7d240c" />
+    <item key="3" value="DotSpatial.Controls.MapFrame, DotSpatial.Controls, Version=2.0.0.443, Culture=neutral, PublicKeyToken=4d9e49339a7d240c" />
+    <item key="4" value="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="5" value="DotSpatial.Data.Extent, DotSpatial.Data, Version=2.0.0.443, Culture=neutral, PublicKeyToken=c29dbf30e059ca9d" />
+    <item key="6" value="System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="7" value="DotSpatial.Controls.MapLayerCollection, DotSpatial.Controls, Version=2.0.0.443, Culture=neutral, PublicKeyToken=4d9e49339a7d240c" />
+    <item key="8" value="System.Collections.Generic.List`1[[DotSpatial.Symbology.ILayer, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="9" value="DotSpatial.Controls.MapPolygonLayer, DotSpatial.Controls, Version=2.0.0.443, Culture=neutral, PublicKeyToken=4d9e49339a7d240c" />
+    <item key="10" value="DotSpatial.Symbology.PolygonScheme, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="11" value="DotSpatial.Symbology.PolygonCategoryCollection, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="12" value="System.Collections.Generic.List`1[[DotSpatial.Symbology.IPolygonCategory, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="13" value="DotSpatial.Symbology.PolygonCategory, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="14" value="DotSpatial.Symbology.PolygonSymbolizer, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="15" value="DotSpatial.Symbology.LineSymbolizer, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="16" value="DotSpatial.Data.CopyList`1[[DotSpatial.Symbology.IStroke, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387]], DotSpatial.Data, Version=2.0.0.443, Culture=neutral, PublicKeyToken=c29dbf30e059ca9d" />
+    <item key="17" value="System.Collections.Generic.List`1[[DotSpatial.Symbology.IStroke, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="18" value="DotSpatial.Symbology.SimpleStroke, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="19" value="System.Drawing.Color, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <item key="20" value="System.Drawing.Drawing2D.DashStyle, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <item key="21" value="System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="22" value="DotSpatial.Symbology.StrokeStyle, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="23" value="DotSpatial.Symbology.ScaleMode, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="24" value="System.Drawing.GraphicsUnit, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <item key="25" value="DotSpatial.Data.CopyList`1[[DotSpatial.Symbology.IPattern, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387]], DotSpatial.Data, Version=2.0.0.443, Culture=neutral, PublicKeyToken=c29dbf30e059ca9d" />
+    <item key="26" value="System.Collections.Generic.List`1[[DotSpatial.Symbology.IPattern, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="27" value="DotSpatial.Symbology.SimplePattern, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="28" value="DotSpatial.Symbology.PatternType, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="29" value="DotSpatial.Data.PolygonShapefile, DotSpatial.Data, Version=2.0.0.443, Culture=neutral, PublicKeyToken=c29dbf30e059ca9d" />
+    <item key="30" value="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <item key="31" value="DotSpatial.Symbology.DynamicVisibilityMode, DotSpatial.Symbology, Version=2.0.0.443, Culture=neutral, PublicKeyToken=6178c08da7998387" />
+    <item key="32" value="System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  </types>
+  <item type="1" />
+  <item type="2">
+    <member name="MapFrame" type="3">
+      <member name="IsLegendGroup" type="4" value="False" />
+      <member name="ViewExtents" type="5">
+        <member name="MaxX" type="6" value="13194662.8474311" />
+        <member name="MaxY" type="6" value="7640917.98545292" />
+        <member name="MinX" type="6" value="-13171271.7362489" />
+        <member name="MinY" type="6" value="-7644776.65857171" />
+      </member>
+      <member name="ExtendBuffer" type="4" value="False" />
+      <member name="Layers" type="7">
+        <member name="InnerList" type="8">
+          <item type="9">
+            <member name="IsLegendGroup" type="4" value="False" />
+            <member name="Symbology" type="10" id="2">
+              <member name="IsLegendGroup" type="4" value="False" />
+              <member name="Categories" type="11">
+                <member name="InnerList" type="12">
+                  <item type="13">
+                    <member name="IsLegendGroup" type="4" value="False" />
+                    <member name="SelectionSymbolizer" type="14">
+                      <member name="IsLegendGroup" type="4" value="False" />
+                      <member name="OutlineSymbolizer" type="15" id="0">
+                        <member name="IsLegendGroup" type="4" value="False" />
+                        <member name="Strokes" type="16">
+                          <member name="InnerList" type="17">
+                            <item type="18">
+                              <member name="Color" type="19" value="Cyan" />
+                              <member name="DashStyle" type="20" value="Solid" />
+                              <member name="Opacity" type="21" value="1" />
+                              <member name="Width" type="6" value="2" />
+                              <member name="StrokeStyle" type="22" value="Simple" />
+                            </item>
+                          </member>
+                        </member>
+                        <member name="IsVisible" type="4" value="True" />
+                        <member name="ScaleModes" type="23" value="Simple" />
+                        <member name="Smoothing" type="4" value="True" />
+                        <member name="Units" type="24" value="Pixel" />
+                        <member name="IsExpanded" type="4" value="False" />
+                        <member name="LegendTextReadOnly" type="4" value="False" />
+                      </member>
+                      <member name="Patterns" type="25">
+                        <member name="InnerList" type="26">
+                          <item type="27">
+                            <member name="FillColor" type="19" value="Transparent" />
+                            <member name="Opacity" type="21" value="0" />
+                            <member name="Outline" ref="0" />
+                            <member name="PatternType" type="28" value="Gradient" />
+                            <member name="UseOutline" type="4" value="True" />
+                          </item>
+                        </member>
+                      </member>
+                      <member name="IsVisible" type="4" value="True" />
+                      <member name="ScaleModes" type="23" value="Simple" />
+                      <member name="Smoothing" type="4" value="True" />
+                      <member name="Units" type="24" value="Pixel" />
+                      <member name="IsExpanded" type="4" value="False" />
+                      <member name="LegendTextReadOnly" type="4" value="False" />
+                    </member>
+                    <member name="Symbolizer" type="14">
+                      <member name="IsLegendGroup" type="4" value="False" />
+                      <member name="OutlineSymbolizer" type="15" id="1">
+                        <member name="IsLegendGroup" type="4" value="False" />
+                        <member name="Strokes" type="16">
+                          <member name="InnerList" type="17">
+                            <item type="18">
+                              <member name="Color" type="19" value="#9B5404" />
+                              <member name="DashStyle" type="20" value="Solid" />
+                              <member name="Opacity" type="21" value="1" />
+                              <member name="Width" type="6" value="1" />
+                              <member name="StrokeStyle" type="22" value="Simple" />
+                            </item>
+                          </member>
+                        </member>
+                        <member name="IsVisible" type="4" value="True" />
+                        <member name="ScaleModes" type="23" value="Simple" />
+                        <member name="Smoothing" type="4" value="True" />
+                        <member name="Units" type="24" value="Pixel" />
+                        <member name="IsExpanded" type="4" value="False" />
+                        <member name="LegendTextReadOnly" type="4" value="False" />
+                      </member>
+                      <member name="Patterns" type="25">
+                        <member name="InnerList" type="26">
+                          <item type="27">
+                            <member name="FillColor" type="19" value="#FCD1A1" />
+                            <member name="Opacity" type="21" value="1" />
+                            <member name="Outline" ref="1" />
+                            <member name="PatternType" type="28" value="Gradient" />
+                            <member name="UseOutline" type="4" value="True" />
+                          </item>
+                        </member>
+                      </member>
+                      <member name="IsVisible" type="4" value="True" />
+                      <member name="ScaleModes" type="23" value="Simple" />
+                      <member name="Smoothing" type="4" value="True" />
+                      <member name="Units" type="24" value="Pixel" />
+                      <member name="IsExpanded" type="4" value="False" />
+                      <member name="LegendTextReadOnly" type="4" value="False" />
+                    </member>
+                    <member name="IsExpanded" type="4" value="False" />
+                    <member name="LegendTextReadOnly" type="4" value="False" />
+                  </item>
+                </member>
+                <member name="Scheme" ref="2" arg="0" />
+              </member>
+              <member name="AppearsInLegend" type="4" value="False" />
+              <member name="IsExpanded" type="4" value="False" />
+              <member name="LegendTextReadOnly" type="4" value="False" />
+            </member>
+            <member name="DataSet" type="29" arg="0" useCase="Both">
+              <member name="UseStaticOpenMethod" type="4" staticConstructorMethod="Open" staticMethodIndicator="true" value="False" />
+              <member name="FilePath" type="30" arg="0" useCase="Both" value="50m_admin_0_countries.shp" />
+            </member>
+            <member name="ShowLabels" type="4" value="False" />
+            <member name="Snappable" type="4" value="True" />
+            <member name="DynamicVisibilityMode" type="31" value="ZoomedIn" />
+            <member name="DynamicVisibilityWidth" type="6" value="0" />
+            <member name="IsVisible" type="4" value="True" />
+            <member name="SelectionEnabled" type="4" value="True" />
+            <member name="UseDynamicVisibility" type="4" value="False" />
+            <member name="IsExpanded" type="4" value="True" />
+            <member name="LegendText" type="30" value="50m_admin_0_countries" />
+            <member name="LegendTextReadOnly" type="4" value="False" />
+          </item>
+        </member>
+      </member>
+      <member name="ExtentsInitialized" type="4" value="True" />
+      <member name="DynamicVisibilityMode" type="31" value="ZoomedIn" />
+      <member name="DynamicVisibilityWidth" type="6" value="0" />
+      <member name="SelectionEnabled" type="4" value="True" />
+      <member name="UseDynamicVisibility" type="4" value="False" />
+      <member name="IsExpanded" type="4" value="True" />
+      <member name="LegendText" type="30" value="Map Layers" />
+      <member name="LegendTextReadOnly" type="4" value="False" />
+    </member>
+    <member name="ProjectionEsriString" type="30" value="PROJCS[&amp;quot;The_World_From_Space&amp;quot;,GEOGCS[&amp;quot;GCS_Sphere_ARC_INFO&amp;quot;,DATUM[&amp;quot;D_Sphere_ARC_INFO&amp;quot;,SPHEROID[&amp;quot;Custom&amp;quot;,6370997,0]],PRIMEM[&amp;quot;Greenwich&amp;quot;,0],UNIT[&amp;quot;Degree&amp;quot;,0.0174532925199433]], PROJECTION[&amp;quot;Orthographic&amp;quot;],PARAMETER[&amp;quot;False_Easting&amp;quot;,0],PARAMETER[&amp;quot;False_Northing&amp;quot;,0],PARAMETER[&amp;quot;Central_Meridian&amp;quot;,-72.5333333334],PARAMETER[&amp;quot;Scale_Factor&amp;quot;,1],PARAMETER[&amp;quot;Latitude_Of_Origin&amp;quot;,42.5333333333],UNIT[&amp;quot;Meter&amp;quot;,1]]" />
+    <member name="ZoomOutFartherThanMaxExtent" type="4" value="False" />
+  </item>
+  <item type="32">
+    <entry>
+      <key type="30" value="FetchBasemap_BasemapName" />
+      <value type="30" value="None" />
+    </entry>
+    <entry>
+      <key type="30" value="FetchBasemap_Opacity" />
+      <value type="30" value="100" />
+    </entry>
+  </item>
+</root>


### PR DESCRIPTION
When using a map projection of Mercator or Orthographic (possibly others as well) and labeling features there is a small bug that I have been trying to squash all weekend. I believe it is because when the reprojection of the polygons occurs there are some inherent values of NaN for x or y or both. When the labeler tries to determine the centroid of the said features it results in an exception.

Fixes #1199 

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Centroid of feature with NaN coordinates is skipped so that an exception is not thrown,.