### PR TITLE
Screen referenced labels in map snapshot

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,7 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - The possibility to draw linestrings which are inside a geometry collection (#1061)
 - The possibility to use static methods to deserialize objects that were serialized to a dspx file and can't be deserialized correctly via their class constructor (FeatureSet, MapSelfLoadGroup, MapSelfLoadLayers from GdalExtension, SpatiaLiteFeatureSet) (#1061)
 - Default mouse cursor button in layout insert toolbar
+- Screen referenced labels can be used in map snapshot
 
 ### Changed
 - Switched to VS2017 and C#7

--- a/Contributors
+++ b/Contributors
@@ -54,3 +54,4 @@ Joe Houghton
 Matthias Schider <matthias.schilder1@gmail.com>
 Ilya Sosnovsky <yakrewedko@ya.ru>
 Bryan Price <southernprogrammer@gmail.com>
+Abel G. Perez <sindizzy@gmail.com>

--- a/Source/DotSpatial.Controls/Map.cs
+++ b/Source/DotSpatial.Controls/Map.cs
@@ -1078,6 +1078,92 @@ namespace DotSpatial.Controls
         }
 
         /// <summary>
+        /// Captures an image of whatever the contents of the back buffer would be at the size of the screen.
+        /// Since the DotSpatial framework currently does not provide a mechanism for screen referenced labels
+        /// the best we can do in the meantime is to allow the developer to pass in Label objects that are controls
+        /// placed on top of the map.
+        /// </summary>
+        /// <param name="labelList">a list of Label controls</param>
+        /// <returns>A bitmap with the snap shot plus embedded string text.</returns>
+        public Bitmap SnapShot(List<Label> labelList)
+        {
+            Bitmap bmp = SnapShot();
+
+            // inject the labels into the bitmap
+            if (labelList != null && labelList.Count > 0)
+            {
+                using (Graphics gr = Graphics.FromImage(bmp))
+                {
+                    gr.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+
+                    // cycle through each label in the list
+                    foreach (Label lbl in labelList)
+                    {
+                        // the label has to be visible and it must contain text
+                        if (lbl != null && lbl.Visible && !string.IsNullOrWhiteSpace(lbl.Text))
+                        {
+                            // convert top left of label to screen coords
+                            Point ptScr = lbl.PointToScreen(new Point(0, 0));
+
+                            // take the screen point and determine where that point is on the map control
+                            Point ptMap = PointToClient(ptScr);
+
+                            // get the label rectangle
+                            Rectangle rct = lbl.ClientRectangle;
+
+                            // setup the background rectangle
+                            if (lbl.BackColor != Color.Transparent)
+                            {
+                                // get the label backcolor
+                                Brush brshBak = new SolidBrush(lbl.BackColor);
+
+                                // to create the back area in graphics we can use the rectangle dimensions but we
+                                // need to use proper location
+                                gr.FillRectangle(brshBak, ptMap.X, ptMap.Y, rct.Width, rct.Height);
+                            }
+
+                            // setup the background border
+                            if (lbl.BorderStyle != BorderStyle.None)
+                            {
+                                // get the label border color (assumed to be black)
+                                Pen penBdr = new Pen(Color.Black, 1);
+
+                                // to create the back border in graphics we can use the rectangle dimensions but we
+                                // need to use proper location
+                                gr.DrawRectangle(penBdr, ptMap.X, ptMap.Y, rct.Width, rct.Height);
+                            }
+
+                            // set up the text part
+                            string txt = lbl.Text;
+                            Font fnt = lbl.Font;
+                            SolidBrush brsh = new SolidBrush(lbl.ForeColor);
+
+                            // draw the text string directly on the bitmap
+                            gr.DrawString(txt, fnt, brsh, ptMap);
+                        }
+                    }
+                }
+            }
+
+            // return the modified bitmap
+            return bmp;
+        }
+
+        /// <summary>
+        /// Captures an image of whatever the contents of the back buffer would be at the size of the screen.
+        /// Since the DotSpatial framework currently does not provide a mechanism for screen referenced labels
+        /// the best we can do in the meantime is to allow the developer to pass in Label objects that are controls
+        /// placed on top of the map.
+        /// </summary>
+        /// <param name="lbl">a Label control</param>
+        /// <returns>A bitmap with the snap shot plus embedded string text.</returns>
+        public Bitmap SnapShot(Label lbl)
+        {
+            List<Label> labelList = new List<Label>() { lbl };
+            return SnapShot(labelList);
+        }
+
+        /// <summary>
         /// Adds any members found in the specified region to the selected state as long as SelectionEnabled is set to true.
         /// </summary>
         /// <param name="tolerant">The geographic region where selection occurs that is tolerant for point or linestrings.</param>


### PR DESCRIPTION
Since the DotSpatial framework currently does not provide a mechanism for screen referenced labels the best we can do in the meantime is to allow the developer to pass in Label objects that are controls placed on top of the map. This code overloads the Map.Snapshot routine to allow .NET labels to be included in the exported map bitmap.

Fixes #1161 

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Label controls which are screen referenced can be included in map snapshots. For example a title or footnote label that does not change coordinates with a change in map extents.