### PR TITLE
A function to clone a FeatureSet and then reproject it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,7 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - The possibility to draw linestrings which are inside a geometry collection (#1061)
 - The possibility to use static methods to deserialize objects that were serialized to a dspx file and can't be deserialized correctly via their class constructor (FeatureSet, MapSelfLoadGroup, MapSelfLoadLayers from GdalExtension, SpatiaLiteFeatureSet) (#1061)
 - Default mouse cursor button in layout insert toolbar
+- A function to get a reprojected clone of a featureset
 
 ### Changed
 - Switched to VS2017 and C#7

--- a/Contributors
+++ b/Contributors
@@ -54,3 +54,4 @@ Joe Houghton
 Matthias Schider <matthias.schilder1@gmail.com>
 Ilya Sosnovsky <yakrewedko@ya.ru>
 Bryan Price <southernprogrammer@gmail.com>
+Abel G. Perez <sindizzy@gmail.com>

--- a/Source/DotSpatial.Data/FeatureSetExt.cs
+++ b/Source/DotSpatial.Data/FeatureSetExt.cs
@@ -249,8 +249,6 @@ namespace DotSpatial.Data
         /// <returns>A reprojected clone of the surce FeatureSet</returns>
         public static IFeatureSet ReprojectedClone(this IFeatureSet self, ProjectionInfo targetPrj)
         {
-            try
-            {
                 // input check
                 if (self == null || targetPrj == null)
                 {
@@ -264,11 +262,6 @@ namespace DotSpatial.Data
 
                 // success so return the reprojected clone FeatureSet
                 return fsClone;
-            }
-            catch
-            {
-                return null;
-            }
         }
 
         /// <summary>

--- a/Source/DotSpatial.Data/FeatureSetExt.cs
+++ b/Source/DotSpatial.Data/FeatureSetExt.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using DotSpatial.NTSExtension;
+using DotSpatial.Projections;
 using GeoAPI.Geometries;
 
 namespace DotSpatial.Data
@@ -237,6 +238,37 @@ namespace DotSpatial.Data
         public static bool Intersects(this IFeature self, Envelope env)
         {
             return self.Geometry.EnvelopeInternal.Intersects(env) && self.Geometry.Intersects(env.ToPolygon());
+        }
+
+        /// <summary>
+        /// This routine takes a DotSpatial Featureset and makes a clone and then reprojects it to the requested Projection.
+        /// It returns a clone of the input so the input is not altered in any way.
+        /// </summary>
+        /// <param name="self">This featureSet</param>
+        /// <param name="targetPrj">The projection of the target clone FeatureSet</param>
+        /// <returns>A reprojected clone of the surce FeatureSet</returns>
+        public static IFeatureSet ReprojectedClone(this IFeatureSet self, ProjectionInfo targetPrj)
+        {
+            try
+            {
+                // input check
+                if (self == null || targetPrj == null)
+                {
+                    return null;
+                }
+
+                self.FillAttributes();
+                IFeatureSet fsClone = self.CopyFeatures(true);
+                fsClone.IndexMode = false;
+                fsClone.Reproject(targetPrj);
+
+                // success so return the reprojected clone FeatureSet
+                return fsClone;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This routine takes a DotSpatial FeatureSet and makes a clone and then reprojects it to the requested Projection. It returns a clone of the input so the input is not altered in any way. This is in contrast to FeatureSet .Reproject which does alter the source FeatureSet.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Adds a new function.