### PR TITLE
Fix layer dynamic visibility in map group

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -149,5 +149,7 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Shape File Saves with Wrong DataTypes (#1005)
 - Calculation of translation param in InRamImageData.GetBitmap is defective (#1203)
 - MapImageLayer not drawn correctly on print (#1137)
+- MapRasterLayer not drawn correctly on print
 - Create Categories for symbology is inconsistent with large datasets (#1242)
+- Geographic projections now have a Name property
 - Fixes logic defect where dynamic visbility for a layer in a map group would not work properly (#1289)

--- a/Changelog.md
+++ b/Changelog.md
@@ -150,3 +150,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Calculation of translation param in InRamImageData.GetBitmap is defective (#1203)
 - MapImageLayer not drawn correctly on print (#1137)
 - Create Categories for symbology is inconsistent with large datasets (#1242)
+- Fixes logic defect where dynamic visbility for a layer in a map group would not work properly (#1289)

--- a/Contributors
+++ b/Contributors
@@ -54,3 +54,4 @@ Joe Houghton
 Matthias Schider <matthias.schilder1@gmail.com>
 Ilya Sosnovsky <yakrewedko@ya.ru>
 Bryan Price <southernprogrammer@gmail.com>
+Abel G. Perez <sindizzy@gmail.com>

--- a/Source/DotSpatial.Controls/MapGroup.cs
+++ b/Source/DotSpatial.Controls/MapGroup.cs
@@ -218,13 +218,12 @@ namespace DotSpatial.Controls
             if (Layers == null) return;
             foreach (IMapLayer layer in Layers)
             {
-                if (!layer.IsVisible) continue;
-                if (layer.UseDynamicVisibility && ((layer.DynamicVisibilityMode == DynamicVisibilityMode.ZoomedIn && MapFrame.ViewExtents.Width > layer.DynamicVisibilityWidth) || MapFrame.ViewExtents.Width < layer.DynamicVisibilityWidth))
+                if (layer.IsVisible && layer.VisibleAtExtent(MapFrame.ViewExtents))
                 {
-                    continue; // skip the layer if we are zoomed in or out too far.
+                    // draw the layer if it is visible and also visible at the current map extents.
+                    // the function VisibleAtExtent includes DynamicVisibility logic.
+                    layer.DrawRegions(args, regions, selected);
                 }
-
-                layer.DrawRegions(args, regions, selected);
             }
         }
 


### PR DESCRIPTION
Fixes a logic defect with dynamic visibility for layers in a map group. Issue is described here  https://github.com/DotSpatial/DotSpatial/issues/1289 and fix proposed by @VectorZita.

Fixes #1289 

### Checklist

- [ ] I have included examples or tests
- [ x] I have updated the change log
- [ x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- the DrawRegion logic in the MapGroup class was refactored to process dynamic visibility properly.