### PR TITLE
Help redirected to github wiki

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -58,6 +58,7 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Show buttons from layout toolbars as checked while their function is active
 - replaced ContextMenu by ContextMenuStrip inside Legend, so we don't have to draw the images shown in the ContextMenu ourselves (#1069)
 - changed the background color of the LayerDialog and TabControlDialog tabs to Control so they have the same background color as the user controls they contain (#1069)
+- Link of the `Help Plugin` changed to https://github.com/DotSpatial/DotSpatial/wiki (#1339)
 
 ### Removed
 - Removed DotSpatial.Topology assembly (#633)

--- a/Contributors
+++ b/Contributors
@@ -55,3 +55,4 @@ Matthias Schider <matthias.schilder1@gmail.com>
 Ilya Sosnovsky <yakrewedko@ya.ru>
 Bryan Price <southernprogrammer@gmail.com>
 Abel G. Perez <sindizzy@gmail.com>
+Rupak Raj Ghimire <rughimire@gmail.com>

--- a/Source/DotSpatial.Plugins.Help/HelpPlugin.cs
+++ b/Source/DotSpatial.Plugins.Help/HelpPlugin.cs
@@ -14,7 +14,7 @@ namespace DotSpatial.Plugins.Help
     /// </summary>
     public class HelpPlugin : Extension
     {
-        private const string Url = "http://dotspatial.codeplex.com/documentation";
+        private const string Url = "https://github.com/DotSpatial/DotSpatial/wiki";
         private const string HelpMenu = HeaderControl.HeaderHelpItemKey;
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes #1339  .

### Checklist
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
- Click of the Help Icon from Help plugin is redirected to github wiki page (https://github.com/DotSpatial/DotSpatial/wiki) (#1339)
