### PR TITLE
Fix for moving items in legend

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -159,4 +159,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Potential Bug in RasterBoundsExt class CellsContainingExtent(...) method (#1332)
 - Potential bug in EnvelopeExt (and ExtentExt) class Reproportion(...) method (#1326)
 - Bug in AzimuthalEquidistant class (#1342)
-- Bug in moving legend items (#)
+- Bug in moving legend items (#1368)

--- a/Changelog.md
+++ b/Changelog.md
@@ -159,3 +159,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Potential Bug in RasterBoundsExt class CellsContainingExtent(...) method (#1332)
 - Potential bug in EnvelopeExt (and ExtentExt) class Reproportion(...) method (#1326)
 - Bug in AzimuthalEquidistant class (#1342)
+- Bug in moving legend items (#)

--- a/Source/DotSpatial.Controls/Legend.cs
+++ b/Source/DotSpatial.Controls/Legend.cs
@@ -645,7 +645,16 @@ namespace DotSpatial.Controls
                     }
                     else if (_dragTarget.Item.LegendType == LegendType.Layer && _dragItem.Item.LegendType == LegendType.Layer)
                     {
-                        boxOverLine = BoxFromItem(_dragTarget.Item.BottomMember());
+                        if (_dragTarget.Item.IsExpanded)
+                        {
+                            // if layer is expanded then we look for the bottom member of the target item
+                            boxOverLine = BoxFromItem(_dragTarget.Item.BottomMember());
+                        }
+                        else
+                        {
+                            // if layer is collapsed then just use the target item
+                            boxOverLine = _dragTarget;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Moving items in legend was not working. The routine should work if the target layer was collapsed or expanded. this pull request fixes that defect.

Fixes # .

### Checklist

- [ ] I have included examples or tests
- [x ] I have updated the change log
- [ x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Dragging items in the legend was not working correctly. The item move was dependent on the target being collapsed or expanded. this fix ensures that the move will work properly if target is expanded or collapsed.