### PR TITLE
Fix ExtentExt.Reproportion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -159,4 +159,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Potential Bug in RasterBoundsExt class CellsContainingExtent(...) method (#1332)
 - Potential bug in EnvelopeExt (and ExtentExt) class Reproportion(...) method (#1326)
 - Bug in AzimuthalEquidistant class (#1342)
-- Bug in Max Extents discussed in #1351 (#0000)
+- Bug in ExtentExt.Reproportion discussed in #1351 (#1370)

--- a/Changelog.md
+++ b/Changelog.md
@@ -159,3 +159,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Potential Bug in RasterBoundsExt class CellsContainingExtent(...) method (#1332)
 - Potential bug in EnvelopeExt (and ExtentExt) class Reproportion(...) method (#1326)
 - Bug in AzimuthalEquidistant class (#1342)
+- Bug in Max Extents discussed in #1351 (#0000)

--- a/Source/DotSpatial.Symbology/ExtentExt.cs
+++ b/Source/DotSpatial.Symbology/ExtentExt.cs
@@ -27,7 +27,8 @@ namespace DotSpatial.Symbology
             double dy = self.Height * (newRectangle.Y - original.Y) / original.Height;
             double w = self.Width * newRectangle.Width / original.Width;
             double h = self.Height * newRectangle.Height / original.Height;
-            return new Extent(self.X + dx, self.Y + dy, self.X + dx + w, self.Y + dy + h);
+
+            return new Extent(self.X + dx, self.Y + dy - h, self.X + dx + w, self.Y + dy);
         }
 
         #endregion


### PR DESCRIPTION
A bug was introduced in ExtentExt.Reproportion. This pull request fixes it. Discussion https://github.com/DotSpatial/DotSpatial/issues/1351 and proposal from @VectorZita

Co-Authored-By: VectorZita <37071221+VectorZita@users.noreply.github.com>

Fixes #1351.

### Checklist

- [ ] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Calculation for extents in loading a WebMap image in ExtentExt.Reproportion