### PR TITLE
Perez snapshot with screen labels

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## V4.0
 
+### Added
+- Screen referenced labels can be used in map snapshot
+
 ### Changed
 - Switched to VS2022
 - Switched to .Net 6


### PR DESCRIPTION
Rehash of https://github.com/DotSpatial/DotSpatial/pull/1249
Since the DotSpatial framework currently does not provide a mechanism for screen referenced labels the best we can do in the meantime is to allow the developer to pass in Label objects that are controls placed on top of the map. This code overloads the Map.Snapshot routine to allow .NET labels to be included in the exported map bitmap.

Fixes https://github.com/DotSpatial/DotSpatial/issues/1199

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Label controls which are screen referenced can be included in map snapshots. For example, a title or footnote label that does not change coordinates with a change in map extents.