### PR TITLE
Bugfix issue 1474: False polygon outlines are drawn at map boundary

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -209,3 +209,4 @@ Be aware that code written for 1.9 will not work out of the box because DotSpati
 - Bug in AzimuthalEquidistant class (#1342)
 - Bug in moving legend items (#1368)
 - Bug in ExtentExt.Reproportion discussed in #1351 (#1370)
+- False polygon outlines are drawn at map boundary when not in edit mode (#1474)

--- a/Contributors
+++ b/Contributors
@@ -60,5 +60,6 @@ Thomas Stocker <thomas.stocker@gmail.com>
 Tomaso Tonelli <tomaso.tonelli@gmail.com>
 Trent Muhr
 Troy Shields
+Ulrich Egger <u.egger@itwh.de>
 Valeriy Malinovskiy <mdfcnvsn@gmail.com>
 Yang Cao

--- a/Source/Core/DotSpatial.Controls/MapPolygonLayer.cs
+++ b/Source/Core/DotSpatial.Controls/MapPolygonLayer.cs
@@ -421,8 +421,9 @@ namespace DotSpatial.Controls
             }
 
             FastDrawnState state = new(selected, Symbology.Categories[0]);
+
+            Rectangle clipRect = ComputeClippingRectangle(e);
             Extent drawExtents = e.GeographicExtents;
-            Rectangle clipRect = e.ProjToPixel(e.GeographicExtents);
             SoutherlandHodgman shClip = new(clipRect);
 
             List<ShapeRange> shapes = DataSet.ShapeIndices;


### PR DESCRIPTION
Fixes Issue 1474 False Polygon outlines are drawn at map boundary ...

https://github.com/DotSpatial/DotSpatial/issues/1474



### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-