### PR TITLE
Flash shape (proof of concept)

### DIFF
--- a/Source/Examples/DemoGPS/DemoGps.csproj
+++ b/Source/Examples/DemoGPS/DemoGps.csproj
@@ -8,6 +8,11 @@
     <PackageIcon>Gps.ico</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="c#.backup\**" />
+    <EmbeddedResource Remove="c#.backup\**" />
+    <None Remove="c#.backup\**" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="DotSpatial.Controls" Version="4.0.656" />
     <PackageReference Include="DotSpatial.Positioning" Version="4.0.656" />
     <PackageReference Include="DotSpatial.Positioning.Forms" Version="4.0.656" />

--- a/Source/Examples/DotSpatial.Examples.sln
+++ b/Source/Examples/DotSpatial.Examples.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DummyHeaderControl", "Dummy
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleApp", "SimpleApp\SimpleApp.csproj", "{3D5C9BCD-8DA3-40E6-B522-625CC281E5E9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlashShape", "FlashShape\FlashShape.csproj", "{CF8FED00-C068-4AF6-91FD-8DB9333410B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{3D5C9BCD-8DA3-40E6-B522-625CC281E5E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3D5C9BCD-8DA3-40E6-B522-625CC281E5E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D5C9BCD-8DA3-40E6-B522-625CC281E5E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF8FED00-C068-4AF6-91FD-8DB9333410B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF8FED00-C068-4AF6-91FD-8DB9333410B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF8FED00-C068-4AF6-91FD-8DB9333410B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF8FED00-C068-4AF6-91FD-8DB9333410B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Examples/FlashShape/FlashShape.csproj
+++ b/Source/Examples/FlashShape/FlashShape.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotSpatial.Controls" Version="4.0.656" />
+    <PackageReference Include="DotSpatial.Data" Version="4.0.656" />
+    <PackageReference Include="DotSpatial.Extensions" Version="4.0.656" />
+    <PackageReference Include="DotSpatial.Projections.Forms" Version="4.0.656" />
+    <PackageReference Include="DotSpatial.Serialization" Version="4.0.656" />
+    <PackageReference Include="DotSpatial.Symbology" Version="4.0.656" />
+    <PackageReference Include="DotSpatial.Topology" Version="1.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Examples/FlashShape/Form1.Designer.cs
+++ b/Source/Examples/FlashShape/Form1.Designer.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) DotSpatial Team. All rights reserved.
+// Licensed under the MIT, license. See License.txt file in the project root for full license information.
+
+using DotSpatial.Controls;
+
+namespace FlashShape
+{
+    partial class Form1
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+            this.appManager1 = new DotSpatial.Controls.AppManager();
+            this.btnFlashFirstShape = new System.Windows.Forms.Button();
+            this.btnFlashFirstSelectedShape = new System.Windows.Forms.Button();
+            this.btnFlashLastShape = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // appManager1
+            // 
+            this.appManager1.Directories = ((System.Collections.Generic.List<string>)(resources.GetObject("appManager1.Directories")));
+            this.appManager1.DockManager = null;
+            this.appManager1.HeaderControl = null;
+            this.appManager1.Legend = null;
+            this.appManager1.Map = null;
+            this.appManager1.ProgressHandler = null;
+            // 
+            // btnFlashFirstShape
+            // 
+            this.btnFlashFirstShape.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnFlashFirstShape.Location = new System.Drawing.Point(12, 365);
+            this.btnFlashFirstShape.Name = "btnFlashFirstShape";
+            this.btnFlashFirstShape.Size = new System.Drawing.Size(118, 23);
+            this.btnFlashFirstShape.TabIndex = 0;
+            this.btnFlashFirstShape.Text = "Flash First Shape";
+            this.btnFlashFirstShape.UseVisualStyleBackColor = true;
+            this.btnFlashFirstShape.Click += new System.EventHandler(this.btnFlashFirstShape_Click);
+            // 
+            // btnFlashFirstSelectedShape
+            // 
+            this.btnFlashFirstSelectedShape.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnFlashFirstSelectedShape.Location = new System.Drawing.Point(12, 438);
+            this.btnFlashFirstSelectedShape.Name = "btnFlashFirstSelectedShape";
+            this.btnFlashFirstSelectedShape.Size = new System.Drawing.Size(118, 23);
+            this.btnFlashFirstSelectedShape.TabIndex = 1;
+            this.btnFlashFirstSelectedShape.Text = "Flash First Selected";
+            this.btnFlashFirstSelectedShape.UseVisualStyleBackColor = true;
+            this.btnFlashFirstSelectedShape.Click += new System.EventHandler(this.btnFlashFirstSelectedShape_Click);
+            // 
+            // btnFlashLastShape
+            // 
+            this.btnFlashLastShape.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnFlashLastShape.Location = new System.Drawing.Point(12, 394);
+            this.btnFlashLastShape.Name = "btnFlashLastShape";
+            this.btnFlashLastShape.Size = new System.Drawing.Size(118, 23);
+            this.btnFlashLastShape.TabIndex = 2;
+            this.btnFlashLastShape.Text = "Flash Last Shape";
+            this.btnFlashLastShape.UseVisualStyleBackColor = true;
+            this.btnFlashLastShape.Click += new System.EventHandler(this.btnFlashLastShape_Click);
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(779, 503);
+            this.Controls.Add(this.btnFlashLastShape);
+            this.Controls.Add(this.btnFlashFirstSelectedShape);
+            this.Controls.Add(this.btnFlashFirstShape);
+            this.Name = "Form1";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Form1";
+            this.Load += new System.EventHandler(this.Form1_Load);
+            this.ResumeLayout(false);
+
+        }
+
+        private AppManager appManager1;
+
+        #endregion
+
+        private Button btnFlashFirstShape;
+        private Button btnFlashFirstSelectedShape;
+        private Button btnFlashLastShape;
+    }
+}

--- a/Source/Examples/FlashShape/Form1.Designer.cs
+++ b/Source/Examples/FlashShape/Form1.Designer.cs
@@ -38,6 +38,7 @@ namespace FlashShape
             this.btnFlashFirstShape = new System.Windows.Forms.Button();
             this.btnFlashFirstSelectedShape = new System.Windows.Forms.Button();
             this.btnFlashLastShape = new System.Windows.Forms.Button();
+            this.btnFlashShapeIndex = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // appManager1
@@ -52,7 +53,7 @@ namespace FlashShape
             // btnFlashFirstShape
             // 
             this.btnFlashFirstShape.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btnFlashFirstShape.Location = new System.Drawing.Point(12, 365);
+            this.btnFlashFirstShape.Location = new System.Drawing.Point(12, 335);
             this.btnFlashFirstShape.Name = "btnFlashFirstShape";
             this.btnFlashFirstShape.Size = new System.Drawing.Size(118, 23);
             this.btnFlashFirstShape.TabIndex = 0;
@@ -74,7 +75,7 @@ namespace FlashShape
             // btnFlashLastShape
             // 
             this.btnFlashLastShape.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btnFlashLastShape.Location = new System.Drawing.Point(12, 394);
+            this.btnFlashLastShape.Location = new System.Drawing.Point(12, 364);
             this.btnFlashLastShape.Name = "btnFlashLastShape";
             this.btnFlashLastShape.Size = new System.Drawing.Size(118, 23);
             this.btnFlashLastShape.TabIndex = 2;
@@ -82,11 +83,23 @@ namespace FlashShape
             this.btnFlashLastShape.UseVisualStyleBackColor = true;
             this.btnFlashLastShape.Click += new System.EventHandler(this.btnFlashLastShape_Click);
             // 
+            // btnFlashShapeIndex
+            // 
+            this.btnFlashShapeIndex.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnFlashShapeIndex.Location = new System.Drawing.Point(12, 393);
+            this.btnFlashShapeIndex.Name = "btnFlashShapeIndex";
+            this.btnFlashShapeIndex.Size = new System.Drawing.Size(118, 23);
+            this.btnFlashShapeIndex.TabIndex = 3;
+            this.btnFlashShapeIndex.Text = "Flash Shape Index...";
+            this.btnFlashShapeIndex.UseVisualStyleBackColor = true;
+            this.btnFlashShapeIndex.Click += new System.EventHandler(this.btnFlashShapeIndex_Click);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(779, 503);
+            this.Controls.Add(this.btnFlashShapeIndex);
             this.Controls.Add(this.btnFlashLastShape);
             this.Controls.Add(this.btnFlashFirstSelectedShape);
             this.Controls.Add(this.btnFlashFirstShape);
@@ -105,5 +118,6 @@ namespace FlashShape
         private Button btnFlashFirstShape;
         private Button btnFlashFirstSelectedShape;
         private Button btnFlashLastShape;
+        private Button btnFlashShapeIndex;
     }
 }

--- a/Source/Examples/FlashShape/Form1.cs
+++ b/Source/Examples/FlashShape/Form1.cs
@@ -18,6 +18,8 @@ using NetTopologySuite.Geometries;
 using static System.Net.Mime.MediaTypeNames;
 using System.Diagnostics;
 using DotSpatial.Symbology.Forms;
+using DotSpatial.Data.Forms;
+using Microsoft.VisualBasic;
 
 namespace FlashShape
 {
@@ -79,7 +81,7 @@ namespace FlashShape
 
         private void btnFlashFirstShape_Click(object sender, EventArgs e)
         {
-            // get the first shape of the first layer
+            // get the first shape of the first layer and flash it
             if (appManager1.Map.Layers.Count > 0)
             {
                 MapPolygonLayer lyr = (MapPolygonLayer)appManager1.Map.Layers[0];
@@ -94,13 +96,13 @@ namespace FlashShape
 
         private void btnFlashLastShape_Click(object sender, EventArgs e)
         {
-            // get the first shape of the first layer
+            // get the last shape of the first layer and flash it
             if (appManager1.Map.Layers.Count > 0)
             {
                 MapPolygonLayer lyr = (MapPolygonLayer)appManager1.Map.Layers[0];
                 if (lyr.FeatureSet.Features.Count > 0)
                 {
-                    // our checks are done so flash the first shape in the shapefile
+                    // our checks are done so flash the last shape in the shapefile
                     int lastIdx = lyr.FeatureSet.Features.Count() - 1;
                     var lastFeat = lyr.FeatureSet.Features[lastIdx];
                     FlashFeature(lyr, lastFeat);
@@ -108,8 +110,35 @@ namespace FlashShape
             }
         }
 
+        private void btnFlashShapeIndex_Click(object sender, EventArgs e)
+        {
+            // get the index of the shape of the first layer from the user and flash it
+            if (appManager1.Map.Layers.Count > 0)
+            {
+                MapPolygonLayer lyr = (MapPolygonLayer)appManager1.Map.Layers[0];
+                if (lyr.FeatureSet.Features.Count > 0)
+                {
+                    //ask the user what shape index to flash
+                    var resp = Interaction.InputBox("What shape index would you like to flash?", "Shape index...", "26");
+                    int idx = int.Parse(resp);
+                    if (idx < 0 || idx > lyr.FeatureSet.Features.Count - 1)
+                    {
+                        MessageBox.Show("Shape index out of range of FeatureSet.", "Out of range", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        return;
+                    }
+
+                    // our checks are done so flash the shape in the shapefile
+                    var lastFeat = lyr.FeatureSet.Features[idx];
+                    FlashFeature(lyr, lastFeat);
+                }
+            }
+        }
+
         private void btnFlashFirstSelectedShape_Click(object sender, EventArgs e)
         {
+            MessageBox.Show("Function not working yet.", "In progress...", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+
             //get the first *selected* shape of the first layer
             //todo: the feature selection doesnt seem to be working
             if (appManager1.Map.Layers.Count > 0)
@@ -294,5 +323,6 @@ namespace FlashShape
             System.Windows.Forms.Application.DoEvents();
             grll = null;
         }
+
     }
 }

--- a/Source/Examples/FlashShape/Form1.cs
+++ b/Source/Examples/FlashShape/Form1.cs
@@ -1,0 +1,313 @@
+// Copyright (c) DotSpatial Team. All rights reserved.
+// Licensed under the MIT, license. See License.txt file in the project root for full license information.
+
+
+using System.ComponentModel.Composition;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using System.Windows.Forms;
+using DotSpatial.Controls;
+using DotSpatial.Data;
+//using DotSpatial.NTSExtension;
+using DotSpatial.Symbology;
+using NetTopologySuite.Geometries;
+//using Point = System.Drawing.Point;
+using static System.Net.Mime.MediaTypeNames;
+using System.Diagnostics;
+using DotSpatial.Symbology.Forms;
+
+namespace FlashShape
+{
+    public partial class Form1 : Form
+    {
+        /// <summary>
+        /// Is needed to load extensions.
+        /// </summary>
+        [Export("Shell", typeof(ContainerControl))]
+#pragma warning disable IDE0052 // Ungelesene private Member entfernen
+        private static ContainerControl Shell;
+#pragma warning restore IDE0052 // Ungelesene private Member entfernen
+
+        /// <summary>
+        /// Initializes a new Form1.
+        /// </summary>
+        public Form1()
+        {
+            InitializeComponent();
+
+            if (DesignMode)
+            {
+                return;
+            }
+
+            // These 2 lines are required to load extensions
+            Shell = this;
+            appManager1.LoadExtensions();
+        }
+
+        private void Form1_Load(object sender, EventArgs e)
+        {
+            //appManager1.Map = new Map();
+            //appManager1.Legend= new Legend();   
+            //appManager1.DockManager= new SpatialDockManager();  
+            ////var mf = map.MapFrame;
+
+            // open up the lakes shapefile and add it to the map
+            string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string fileName = Path.Combine(assemblyPath, "Shapefiles", "lakes.shp");
+            Debug.Print("filename={0}", fileName);
+            IFeatureSet fs = FeatureSet.Open(fileName);
+
+            MapPolygonLayer lyr = new(fs)
+            {
+                Symbolizer =
+                {
+                    ScaleMode = ScaleMode.Symbolic,
+                    Smoothing = true
+                },
+                MapFrame = appManager1.Map.MapFrame
+            };
+
+            // select 2 shapes
+            lyr.SelectByAttribute("[NAME] IN('Lake Erie', 'Lake Michigan')");
+
+            appManager1.Map.Layers.Add(lyr);
+        }
+
+        private void btnFlashFirstShape_Click(object sender, EventArgs e)
+        {
+            // get the first shape of the first layer
+            if (appManager1.Map.Layers.Count > 0)
+            {
+                MapPolygonLayer lyr = (MapPolygonLayer)appManager1.Map.Layers[0];
+                if (lyr.FeatureSet.Features.Count > 0)
+                {
+                    // our checks are done so flash the first shape in the shapefile
+                    var firstFeat = lyr.FeatureSet.Features[0];
+                    FlashFeature(lyr, firstFeat);
+                }
+            }
+        }
+
+        private void btnFlashLastShape_Click(object sender, EventArgs e)
+        {
+            // get the first shape of the first layer
+            if (appManager1.Map.Layers.Count > 0)
+            {
+                MapPolygonLayer lyr = (MapPolygonLayer)appManager1.Map.Layers[0];
+                if (lyr.FeatureSet.Features.Count > 0)
+                {
+                    // our checks are done so flash the first shape in the shapefile
+                    int lastIdx = lyr.FeatureSet.Features.Count() - 1;
+                    var lastFeat = lyr.FeatureSet.Features[lastIdx];
+                    FlashFeature(lyr, lastFeat);
+                }
+            }
+        }
+
+        private void btnFlashFirstSelectedShape_Click(object sender, EventArgs e)
+        {
+            //get the first *selected* shape of the first layer
+            if (appManager1.Map.Layers.Count > 0)
+            {
+                //MapPolygonLayer lyr = (MapPolygonLayer)appManager1.Map.Layers[0];
+                //Debug.Print("selection count={0}", lyr.Selection.Count);
+                //if (lyr.Selection.Count > 0)
+                //{
+                //    // our checks are done so flash the first *selected* shape in the shapefile
+                //    var sel = lyr.Selection.ToFeatureSet();
+                //    var firstSelFeat = sel.Features[0];
+                //    FlashFeature(lyr, firstSelFeat);
+                //}
+
+                //Dim plyrSel As IMapPointLayer = CType(mlyrSel, IMapPointLayer)
+                //Dim flyrSel As IMapFeatureLayer = CType(mlyrSel, IMapFeatureLayer)
+                //Dim fsSel As IFeatureSet = flyrSel.DataSet
+
+                //IMapLayer mapLyr = appManager1.Map.Layers[0];
+                //IMapPolygonLayer pgnLyr = (IMapPolygonLayer)mapLyr;
+                //IMapFeatureLayer mapFeatLyr = (IMapFeatureLayer)mapLyr;
+                //IFeatureLayer featLyr = (IFeatureLayer)mapLyr;
+                //if (featLyr.Selection.Count > 0)
+                //{
+                //    // our checks are done so flash the first *selected* shape in the shapefile
+                //    var selFeats = mapFeatLyr.Selection.ToFeatureSet();
+                //    var firstSelFeat = selFeats.Features[0];
+                //    FlashFeature(featLyr, firstSelFeat);
+                //}
+            }
+        }
+
+        /// <summary>
+        /// Will simulate flash of a polygon shape by changing its outline and fill color for several seconds and will also
+        /// display a crosshair across the map centered on the shape. Tested with a polygon shapefile but should work with
+        /// lines and points.
+        /// </summary>
+        /// <param name="featLyr">The feature layer that contains the feature to flash.</param>
+        /// <param name="feat">The feature to flash.</param>
+        /// <remarks>
+        /// Needs some work as I couldnt get the shape to flash on and off without refreshing the map. Probably overkill
+        /// with the Redraw and the DoEvents.
+        /// </remarks>
+        public void FlashFeature(IFeatureLayer featLyr, IFeature feat)
+        {
+            FlashFeature(featLyr, feat, 3);
+        }
+
+        /// <summary>
+        /// Will simulate flash of a polygon shape by changing its outline and fill color for several seconds and will also
+        /// display a crosshair across the map centered on the shape. Tested with a polygon shapefile but should work with
+        /// lines and points.
+        /// </summary>
+        /// <param name="featLyr">The feature layer that contains the feature to flash.</param>
+        /// <param name="feat">The feature to flash.</param>
+        /// <param name="cycleCount">Number of cycles to turn the shape on and off</param>
+        /// <remarks>
+        /// Needs some work as I couldnt get the shape to flash on and off without refreshing the map. Probably overkill
+        /// with the Redraw and the DoEvents.
+        /// </remarks>
+        public void FlashFeature(IFeatureLayer featLyr, IFeature feat, int cycleCount)
+        {
+            if (feat == null)
+                return;
+
+            if (cycleCount < 0 || cycleCount > 20)
+                cycleCount = 3;
+
+            var map = appManager1.Map;
+            var mf = appManager1.Map.MapFrame;
+
+            Debug.Print("fid={0}", feat.Fid);
+
+            // *********************************************************************************************************************
+            // get the centroid of the shape as a point
+            // *********************************************************************************************************************
+            var pt = feat.Geometry.Centroid;
+
+            // *********************************************************************************************************************
+            // get the extents of the map
+            // *********************************************************************************************************************
+            var ext = map.Extent;
+
+            // *********************************************************************************************************************
+            // now draw two fat lines, one vertical and one horizontal to bring focus the center of the shape.
+            // extend the line from each side of the map extents to center of the geometry.
+            // *********************************************************************************************************************
+            var coord1 = new Coordinate(pt.X, ext.MinY);
+            var coord2 = new Coordinate(pt.X, ext.MaxY);
+            var coordsH = new List<Coordinate> { coord1, coord2 };// horizontal
+
+            var coord3 = new Coordinate(ext.MinX, pt.Y);
+            var coord4 = new Coordinate(ext.MaxX, pt.Y);
+            var coordsV = new List<Coordinate> { coord3, coord4 };// vertical
+
+            LineString ls = new LineString(coordsH.ToArray());
+            FeatureSet fs = new FeatureSet(FeatureType.Line);
+            fs.AddFeature(ls);
+            ls = new LineString(coordsV.ToArray());
+            fs.AddFeature(ls);
+            MapLineLayer grll = new MapLineLayer(fs)
+            {
+                Symbolizer =
+                        {
+                            ScaleMode = ScaleMode.Symbolic,
+                            Smoothing = true,
+                        },
+                MapFrame = mf,
+            };
+            grll.Symbolizer.SetFillColor(Color.Cyan);
+            grll.Symbolizer.SetWidth(4);
+            mf.DrawingLayers.Add(grll);
+            mf.Invalidate();
+            map.Invalidate();
+
+            System.Threading.Thread.Sleep(100);
+            System.Windows.Forms.Application.DoEvents();
+
+            // *********************************************************************************************************************
+            // save the original category of the feature. then add a category to the layer with some default drawing properties. a
+            // fill color of green and an outline color of cyan. assign the new category to the feature. this one shape now will take
+            // on the properties of our category.
+            // *********************************************************************************************************************
+            Debug.Print("featLyr type={0}", featLyr.GetType());
+            string catKey = "FlashShape_" + Guid.NewGuid();
+            IFeatureCategory catOrig;
+            IFeatureCategory catNew;
+            if (featLyr.GetType() == typeof(MapPolygonLayer))
+            {
+                var lyr = featLyr as MapPolygonLayer;
+                Debug.Print("catCount={0}", lyr.Symbology.Categories.Count);
+
+                catOrig = lyr.GetCategory(feat);
+
+                catNew = new PolygonCategory(Color.Green, Color.Cyan, 2);
+                catNew.LegendItemVisible = false;
+                catNew.LegendText = catKey;
+                lyr.Symbology.Categories.Add(catNew as PolygonCategory);
+                Debug.Print("catCount={0}", lyr.Symbology.Categories.Count);
+
+                lyr.SetCategory(feat, catNew);
+            }
+            else
+            {
+                throw new NotSupportedException("Unsupported feature type.");
+            }
+
+            // *********************************************************************************************************************
+            // now we change the drawing options of the category. we color the polygon green, pause, then color the polygon red.
+            // And since the category is connected to the shape then it should simulate a flash for a couple cycles, each one being
+            // about 300*2 milliseconds in length. i experimented with various ways to display the flashing but in the end it was a 
+            // combination of applying the color, redrawing the map, and allowing the application to respond that seemed to work.
+            // it may be slow for maps with large amounts of data as it has to redraw in several loops. Overkill on DoEvents?
+            // *********************************************************************************************************************
+            for (int i = 1; i <= cycleCount; i++)
+            {
+                // the first pass colors the shape green and leaves it like that for 300 milliseconds
+                catNew.SetColor(Color.Green);
+                System.Windows.Forms.Application.DoEvents();
+                mf.Invalidate();
+                map.Invalidate();
+                System.Windows.Forms.Application.DoEvents();
+                System.Threading.Thread.Sleep(300);
+                System.Windows.Forms.Application.DoEvents();
+
+                // the second pass colors the shape red and leaves it like that for 300 milliseconds
+                catNew.SetColor(Color.Red);
+                System.Windows.Forms.Application.DoEvents();
+                mf.Invalidate();
+                map.Invalidate();
+                System.Windows.Forms.Application.DoEvents();
+                System.Threading.Thread.Sleep(300);
+                System.Windows.Forms.Application.DoEvents();
+            }
+
+            // *********************************************************************************************************************
+            // now we set the features's category back to the original since we are done flashing. this should set the features's drawing
+            // options back to its original. also remove the category we created since we dont need it anymore.
+            // *********************************************************************************************************************
+            if (featLyr.GetType() == typeof(MapPolygonLayer))
+            {
+                var lyr = featLyr as MapPolygonLayer;
+                Debug.Print("catCount={0}", lyr.Symbology.Categories.Count);
+                lyr.SetCategory(feat, catOrig);
+
+                lyr.Symbology.Categories.Remove(catNew as PolygonCategory);
+                Debug.Print("catCount={0}", lyr.Symbology.Categories.Count);
+            }
+
+            // *********************************************************************************************************************
+            // and finally clear the line drawings
+            // *********************************************************************************************************************
+            System.Threading.Thread.Sleep(100);
+            System.Windows.Forms.Application.DoEvents();
+            mf.DrawingLayers.Remove(grll);
+            map.MapFrame.Invalidate();
+            map.Invalidate();
+            System.Windows.Forms.Application.DoEvents();
+            grll = null;
+        }
+    }
+}

--- a/Source/Examples/FlashShape/Form1.cs
+++ b/Source/Examples/FlashShape/Form1.cs
@@ -111,6 +111,7 @@ namespace FlashShape
         private void btnFlashFirstSelectedShape_Click(object sender, EventArgs e)
         {
             //get the first *selected* shape of the first layer
+            //todo: the feature selection doesnt seem to be working
             if (appManager1.Map.Layers.Count > 0)
             {
                 //MapPolygonLayer lyr = (MapPolygonLayer)appManager1.Map.Layers[0];
@@ -148,28 +149,12 @@ namespace FlashShape
         /// </summary>
         /// <param name="featLyr">The feature layer that contains the feature to flash.</param>
         /// <param name="feat">The feature to flash.</param>
-        /// <remarks>
-        /// Needs some work as I couldnt get the shape to flash on and off without refreshing the map. Probably overkill
-        /// with the Redraw and the DoEvents.
-        /// </remarks>
-        public void FlashFeature(IFeatureLayer featLyr, IFeature feat)
-        {
-            FlashFeature(featLyr, feat, 3);
-        }
-
-        /// <summary>
-        /// Will simulate flash of a polygon shape by changing its outline and fill color for several seconds and will also
-        /// display a crosshair across the map centered on the shape. Tested with a polygon shapefile but should work with
-        /// lines and points.
-        /// </summary>
-        /// <param name="featLyr">The feature layer that contains the feature to flash.</param>
-        /// <param name="feat">The feature to flash.</param>
         /// <param name="cycleCount">Number of cycles to turn the shape on and off</param>
         /// <remarks>
         /// Needs some work as I couldnt get the shape to flash on and off without refreshing the map. Probably overkill
         /// with the Redraw and the DoEvents.
         /// </remarks>
-        public void FlashFeature(IFeatureLayer featLyr, IFeature feat, int cycleCount)
+        public void FlashFeature(IFeatureLayer featLyr, IFeature feat, int cycleCount = 3)
         {
             if (feat == null)
                 return;

--- a/Source/Examples/FlashShape/Form1.resx
+++ b/Source/Examples/FlashShape/Form1.resx
@@ -1,0 +1,75 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="appManager1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="appManager1.Directories" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAEAQAAAH9TeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5MaXN0YDFbW1N5
+        c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVi
+        bGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV1dAwAAAAZfaXRlbXMFX3NpemUIX3ZlcnNpb24GAAAI
+        CAkCAAAAAgAAAAIAAAARAgAAAAQAAAAGAwAAABZBcHBsaWNhdGlvbiBFeHRlbnNpb25zBgQAAAAHUGx1
+        Z2lucw0CCw==
+</value>
+  </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>55</value>
+  </metadata>
+</root>

--- a/Source/Examples/FlashShape/MapLegendExtension.cs
+++ b/Source/Examples/FlashShape/MapLegendExtension.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) DotSpatial Team. All rights reserved.
+// Licensed under the MIT, license. See License.txt file in the project root for full license information.
+
+using System.Windows.Forms;
+using DotSpatial.Controls;
+using DotSpatial.Controls.Docking;
+
+namespace SimpleApp
+{
+    /// <summary>
+    /// Adds a map and a legend to the application.
+    /// </summary>
+    public class MapLegendExtension : Extension
+    {
+        /// <summary>
+        /// Initialzes a new MapLegendExtension.
+        /// </summary>
+        public MapLegendExtension()
+        {
+            DeactivationAllowed = false;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public override int Priority => -100;
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public override void Activate()
+        {
+            base.Activate();
+
+            // Add legend
+            Legend legend = new() { Text = "Legend" };
+            App.Legend = legend;
+            App.DockManager.Add(new DockablePanel("kLegend", "Legend", legend, DockStyle.Left));
+
+            // Add map
+            Map map = new() { Text = "Map", Legend = App.Legend };
+            App.Map = map;
+            App.DockManager.Add(new DockablePanel("kMap", "Map", map, DockStyle.Fill));
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public override void Deactivate()
+        {
+            App.HeaderControl.RemoveAll();
+            App.DockManager.Remove("kLegend");
+            App.DockManager.Remove("kMap");
+            base.Deactivate();
+        }
+    }
+}

--- a/Source/Examples/FlashShape/Program.cs
+++ b/Source/Examples/FlashShape/Program.cs
@@ -1,0 +1,20 @@
+// Copyright (c) DotSpatial Team. All rights reserved.
+// Licensed under the MIT, license. See License.txt file in the project root for full license information.
+
+namespace FlashShape
+{
+    internal static class Program
+    {
+        /// <summary>
+        ///  The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        static void Main()
+        {
+            // To customize application configuration such as set high DPI settings or default font,
+            // see https://aka.ms/applicationconfiguration.
+            ApplicationConfiguration.Initialize();
+            Application.Run(new Form1());
+        }
+    }
+}


### PR DESCRIPTION
This new feature will "flash" a shape. Many times, as a GIS user, I want to know where a certain feature is located without zooming. This new function will draw crosshairs to the feature and "flash' it by alternating the fill color between red and green.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
- Added this function as a new project in the Examples folder as a proof of concept.
- I would like to add this as a context menu or button in the TableEditor control. I did research that approach and tried to mimic the ZoomToSelected method but realized soon that there were many events and triggers that I would have to tweak and am just not familiar enough to successfully add it this way.
- If someone were to point me to where this function should be located and what things I would have to change then I can code that up.
- Maybe this is better implemented as a tool???