### PR TITLE
Plugins.Taudem/Hydrology.cs RunTaudem function does not execute corre…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - LineOrientation fix for Parallel/Perpendicular labels (#1466)
 - Added tests to Appveyor Tests tab (#1489)
 - Shorten column names to max 10 characters on writing to dbf file (#1494)
+- DotSpatial.Plugins.Taudem/Hydrology.cs RunTaudem function does not execute correctly (#1496) 
 
 ## V4.0
 

--- a/Contributors
+++ b/Contributors
@@ -64,3 +64,4 @@ Ulrich Egger <u.egger@itwh.de>
 Valeriy Malinovskiy <mdfcnvsn@gmail.com>
 Yang Cao
 Xin Xu
+mytudousi <mytudousi@126.com>

--- a/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs
+++ b/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs
@@ -1751,6 +1751,7 @@ namespace DotSpatial.Plugins.Taudem
             {
                 StartInfo =
                 {
+                    UseShellExecute = true,
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Minimized,
                     WorkingDirectory = TaudemExeDir(),
@@ -1768,6 +1769,7 @@ namespace DotSpatial.Plugins.Taudem
                 {
                     StartInfo =
                     {
+                        UseShellExecute = true,
                         FileName = Path.GetFileName(tempFile),
                         WorkingDirectory = Path.GetDirectoryName(tempFile)
                     }


### PR DESCRIPTION
…ctly (#1496)
The function RunTaudem in master/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs#L1746.
This function does not execute correctly.
Fixes #1496 

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
In .Net Framework Process.StartInfo.UseShellExecute property default value is true，but in .Net 6.0,default value is false。
So,in file file Hydrology.cs, i add code "UseShellExecute = true" on line1754 and 1772.