### PR TITLE
Explicitly deserialize Xml without XmlSerializer (which is not AOT Friendly)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Added tests to Appveyor Tests tab (#1489)
 - Shorten column names to max 10 characters on writing to dbf file (#1494)
 - DotSpatial.Plugins.Taudem/Hydrology.cs RunTaudem function does not execute correctly (#1496) 
+- Dotspatial.Projections does not work with AOT Compilation (#1500)
 
 ## V4.0
 


### PR DESCRIPTION
Fixes # .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Use XmlReader to Deserialize the datums.xml is AOT and Mobile (Xamarin) friendlier.
  A further advantage of this that no XmlSerialization Assembly needs to be createde on first projection usage. 
  It seems for me that the appveyor run is slightly faster after this checkin.
