### PR TITLE
Taudem set stream shape prj file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Added tests to Appveyor Tests tab (#1489)
 - Shorten column names to max 10 characters on writing to dbf file (#1494)
 - DotSpatial.Plugins.Taudem/Hydrology.cs RunTaudem function does not execute correctly (#1496) 
+- Taudem set stream shape prj file (#1501)
 
 ## V4.0
 

--- a/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs
+++ b/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs
@@ -1751,6 +1751,7 @@ namespace DotSpatial.Plugins.Taudem
             {
                 StartInfo =
                 {
+                    UseShellExecute = true,
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Minimized,
                     WorkingDirectory = TaudemExeDir(),
@@ -1768,6 +1769,7 @@ namespace DotSpatial.Plugins.Taudem
                 {
                     StartInfo =
                     {
+                        UseShellExecute = true,
                         FileName = Path.GetFileName(tempFile),
                         WorkingDirectory = Path.GetDirectoryName(tempFile)
                     }

--- a/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs
+++ b/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs
@@ -899,7 +899,8 @@ namespace DotSpatial.Plugins.Taudem
         public static bool ApplyWatershedSlopeAttribute(string subBasinShapePath, string slopeGridPath, ElevationUnits elevUnits, IProgressHandler callback)
         {
             var path = Path.GetDirectoryName(slopeGridPath);
-            if (path == null) return false;
+            if (path == null)
+                return false;
 
             // CWG 23/1/2011 changed to GeoTiff for Taudem V5
             var tmpClipPath = Path.Combine(path, Path.GetFileNameWithoutExtension(slopeGridPath) + "_clip.tif");
@@ -1726,7 +1727,19 @@ namespace DotSpatial.Plugins.Taudem
                 }
             }
 
-            DataManagement.TryCopy(Path.ChangeExtension(demGridPath, ".prj"), Path.ChangeExtension(streamShapeResultPath, ".prj"));
+            //Set stream shape prj file
+            var myDemPrjFile = Path.ChangeExtension(demGridPath, ".prj");
+            var myStreamShapePrjFile = Path.ChangeExtension(streamShapeResultPath, ".prj");
+            if (File.Exists(myDemPrjFile))
+            {
+                DataManagement.TryCopy(myDemPrjFile, myStreamShapePrjFile);
+            }
+            else
+            {
+                IRaster myDemRaster = Raster.Open(demGridPath);
+                myDemRaster.Projection.SaveAs(myStreamShapePrjFile);
+                myDemRaster.Close();
+            }
 
             callback?.Reset();
 
@@ -2120,7 +2133,8 @@ namespace DotSpatial.Plugins.Taudem
                 var pt = streamShape.GetShape(sindx).Geometry.Coordinates[i];
 
                 RcIndex position = demGrid.ProjToCell(pt.X, pt.Y);
-                if (position.IsEmpty()) continue;
+                if (position.IsEmpty())
+                    continue;
 
                 double currVal = demGrid.Value[position.Row, position.Column];
                 if (currVal < elevLow)
@@ -2168,8 +2182,10 @@ namespace DotSpatial.Plugins.Taudem
 
         private static IFeature MergeAbuttingPolygons(IFeature shape1, IFeature shape2)
         {
-            if (shape1 == null) return shape2;
-            if (shape2 == null) return shape1;
+            if (shape1 == null)
+                return shape2;
+            if (shape2 == null)
+                return shape1;
             IFeature mergeShape = null;
 
             // check both shapes are single parts
@@ -2194,7 +2210,8 @@ namespace DotSpatial.Plugins.Taudem
         /// <returns>The merge result.</returns>
         private static IFeature MergeBasinsByDrainage(IFeatureSet shed, BinTree drainage)
         {
-            if (drainage == null) return null;
+            if (drainage == null)
+                return null;
             IFeature left = MergeBasinsByDrainage(shed, drainage.Left);
             IFeature right = MergeBasinsByDrainage(shed, drainage.Right);
             IFeature lr = MergeAbuttingPolygons(left, right);
@@ -2227,7 +2244,8 @@ namespace DotSpatial.Plugins.Taudem
         /// <returns>The resulting geometry.</returns>
         private static Geometry MergeBasinsByDrainageI(Shapefile shed, BinTree drainage)
         {
-            if (drainage == null) return null;
+            if (drainage == null)
+                return null;
             Geometry left = MergeBasinsByDrainageI(shed, drainage.Left);
             Geometry right = MergeBasinsByDrainageI(shed, drainage.Right);
             IFeature outlet = shed.GetShape(drainage.Val);


### PR DESCRIPTION
Fixes #1501 

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

 first, I determine if the dem grid file contains the .prj file? Yes，use current code. No, do the following.
1、Use the OpenFile function of Raster class, open dem grid file, get IRaster object;
2、Use IRaster.Projection, get ProjectionInfo object;
3、Call IRaster.Dispose() release resource;
4、Call ProjectionInfo.SaveAs() function, save project info as streamShapeResultPath.prj file.