### PR TITLE
Tools.ReSampleGrid can save big raster data with more than 64000000 pixel

### DIFF
--- a/Source/Core/DotSpatial.Data/RasterExt.cs
+++ b/Source/Core/DotSpatial.Data/RasterExt.cs
@@ -40,11 +40,15 @@ namespace DotSpatial.Data
         /// <returns>True, if the whole raster is inside the window.</returns>
         public static bool IsFullyWindowed(this IRaster raster)
         {
-            if (raster.StartRow != 0) return false;
-            if (raster.StartColumn != 0) return false;
+            if (raster.StartRow != 0)
+                return false;
+            if (raster.StartColumn != 0)
+                return false;
 
-            if (raster.EndRow != raster.NumRowsInFile - 1) return false;
-            if (raster.EndColumn != raster.NumColumnsInFile - 1) return false;
+            if (raster.EndRow != raster.NumRowsInFile - 1)
+                return false;
+            if (raster.EndColumn != raster.NumColumnsInFile - 1)
+                return false;
             return true;
         }
 
@@ -144,8 +148,10 @@ namespace DotSpatial.Data
         public static double GetNearestValue(this IRaster raster, Coordinate location)
         {
             RcIndex position = raster.ProjToCell(location.X, location.Y);
-            if (position.Row < 0 || position.Row >= raster.NumRows) return raster.NoDataValue;
-            if (position.Column < 0 || position.Column >= raster.NumColumns) return raster.NoDataValue;
+            if (position.Row < 0 || position.Row >= raster.NumRows)
+                return raster.NoDataValue;
+            if (position.Column < 0 || position.Column >= raster.NumColumns)
+                return raster.NoDataValue;
             return raster.Value[position.Row, position.Column];
         }
 
@@ -160,8 +166,10 @@ namespace DotSpatial.Data
         public static double GetNearestValue(this IRaster raster, double x, double y)
         {
             RcIndex position = raster.ProjToCell(x, y);
-            if (position.Row < 0 || position.Row >= raster.NumRows) return raster.NoDataValue;
-            if (position.Column < 0 || position.Column >= raster.NumColumns) return raster.NoDataValue;
+            if (position.Row < 0 || position.Row >= raster.NumRows)
+                return raster.NoDataValue;
+            if (position.Column < 0 || position.Column >= raster.NumColumns)
+                return raster.NoDataValue;
             return raster.Value[position.Row, position.Column];
         }
 
@@ -176,8 +184,10 @@ namespace DotSpatial.Data
         public static void SetNearestValue(this IRaster raster, double x, double y, double value)
         {
             RcIndex position = raster.ProjToCell(x, y);
-            if (position.Row < 0 || position.Row >= raster.NumRows) return;
-            if (position.Column < 0 || position.Column >= raster.NumColumns) return;
+            if (position.Row < 0 || position.Row >= raster.NumRows)
+                return;
+            if (position.Column < 0 || position.Column >= raster.NumColumns)
+                return;
             raster.Value[position.Row, position.Column] = value;
         }
 
@@ -191,8 +201,10 @@ namespace DotSpatial.Data
         public static void SetNearestValue(this IRaster raster, Coordinate location, double value)
         {
             RcIndex position = raster.ProjToCell(location.X, location.Y);
-            if (position.Row < 0 || position.Row >= raster.NumRows) return;
-            if (position.Column < 0 || position.Column >= raster.NumColumns) return;
+            if (position.Row < 0 || position.Row >= raster.NumRows)
+                return;
+            if (position.Column < 0 || position.Column >= raster.NumColumns)
+                return;
             raster.Value[position.Row, position.Column] = value;
         }
 
@@ -231,7 +243,8 @@ namespace DotSpatial.Data
         /// <returns>The RcIndex that describes the zero based integer row and column indices.</returns>
         public static RcIndex ProjToCell(this IRaster raster, Coordinate location)
         {
-            if (raster?.Bounds == null) return RcIndex.Empty;
+            if (raster?.Bounds == null)
+                return RcIndex.Empty;
             return raster.Bounds.ProjToCell(location);
         }
 
@@ -244,11 +257,77 @@ namespace DotSpatial.Data
         /// <returns>The RcIndex that describes the zero based integer row and column indices.</returns>
         public static RcIndex ProjToCell(this IRaster raster, double x, double y)
         {
-            if (raster?.Bounds == null) return RcIndex.Empty;
+            if (raster?.Bounds == null)
+                return RcIndex.Empty;
             return raster.Bounds.ProjToCell(new Coordinate(x, y));
         }
 
         #endregion
+
+        /// <summary>
+        /// Write raster value in blocks
+        /// </summary>
+        /// <param name="pRaster"></param>
+        /// <param name="pGetValue"></param>
+        /// <param name="pCancelPH"></param>
+        /// <param name="pMaxBlockSize"></param>
+        public static void WriteInBlocks(this IRaster pRaster, Func<int, int, double> pGetValue, ICancelProgressHandler pCancelPH, int pMaxBlockSize = 1000000)
+        {
+            int myRowCount = pRaster.NumRows;
+            int myColumnCount = pRaster.NumColumns;
+
+            //Get Block
+            int myBlockRowCount = pMaxBlockSize / myColumnCount;
+            if (myBlockRowCount == 0)
+            {
+                myBlockRowCount = 1;
+            }
+
+            if (myBlockRowCount > myRowCount)
+            {
+                myBlockRowCount = myRowCount;
+            }
+
+            var myBlockRaster = pRaster.ReadBlock(0, 0, myColumnCount, myBlockRowCount);
+
+            //Write Values
+            int myPrevious = 0;
+            int k = 0;
+            for (int i = 0; i < myRowCount; i++)
+            {
+                for (int j = 0; j < myColumnCount; j++)
+                {
+                    double myValue = pGetValue(i, j);
+                    myBlockRaster.Value[k, j] = myValue;
+                    if (pCancelPH.Cancel)
+                    {
+                        return;
+                    }
+                }
+
+                k++;
+                if (k == myBlockRowCount)
+                {
+                    pRaster.WriteBlock(myBlockRaster, 0, i + 1 - k, myColumnCount, k);
+                    k = 0;
+                }
+
+                //cal process value, only update when increment in persentage
+                int myCurrent = Convert.ToInt32(Math.Round(i * 100D / (myRowCount + 1)));
+                if (myCurrent > myPrevious)
+                {
+                    pCancelPH.Progress(myCurrent, myCurrent.ToString() + "%");
+                    myPrevious = myCurrent;
+                }
+            }
+
+            //Write remaining part
+            if (k > 0)
+            {
+                pRaster.WriteBlock(myBlockRaster, 0, myRowCount - k, myColumnCount, k);
+            }
+        }
+
 
         #endregion
     }

--- a/Source/Core/DotSpatial.Data/Raster{T}.cs
+++ b/Source/Core/DotSpatial.Data/Raster{T}.cs
@@ -482,6 +482,14 @@ namespace DotSpatial.Data
             Value = temp.Value;
         }
 
+        /// <summary>
+        /// Write header info
+        /// </summary>
+        public override void WriteHeader()
+        {
+            this.UpdateHeader();
+        }
+
         /// <inheritdoc/>
         public override void WriteBlock(IRaster blockValues, int xOff, int yOff, int xSize, int ySize)
         {

--- a/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs
+++ b/Source/Extensions/DotSpatial.Plugins.Taudem/Hydrology.cs
@@ -1751,6 +1751,7 @@ namespace DotSpatial.Plugins.Taudem
             {
                 StartInfo =
                 {
+                    UseShellExecute = true,
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Minimized,
                     WorkingDirectory = TaudemExeDir(),
@@ -1768,6 +1769,7 @@ namespace DotSpatial.Plugins.Taudem
                 {
                     StartInfo =
                     {
+                        UseShellExecute = true,
                         FileName = Path.GetFileName(tempFile),
                         WorkingDirectory = Path.GetDirectoryName(tempFile)
                     }


### PR DESCRIPTION
Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
I use Tools.ReSampleGrid，when output raster data is big, the tool has bug, can't save as raster file.I traced the code to see why, Found when row * column >64000000, raster IsInRam is false. when you call the save function, the Data parameter is null. The code is as follows.
public override void Save()
{
       UpdateHeader();
       WriteRaster(Data);
}
So I thought, can such large raster data be saved in blocks, such as 10 million values per commit? After testing I found that it works。And fixed some other bugs int Tools.ReSampleGrid。such as：
output.Projection = input1.Projection;

 Coordinate myCellCoordinate = output.CellToProj(i, j);
myCellCoordinate.X += input1.CellWidth / 2;
myCellCoordinate.Y -= input1.CellHeight / 2;
var myRcIndex = input1.ProjToCell(myCellCoordinate);

My solution is as follows:
-1、In Raster{T}.cs file，i Override implementation function WriteHeader(), code is follows.
public override void WriteHeader()
{
     this.UpdateHeader();
}
-2、In RasterEx.cs file，add function WriteInBlocks. This function can save raster value in blocks，and has a function parameter，which can extend the logic for getting raster values.  code is follows.
public static void WriteInBlocks(this IRaster pRaster, Func<int, int, double> pGetValue, ICancelProgressHandler pCancelPH, int pMaxBlockSize = 1000000)
-3、How to call this function, can see ReSampleGrid.cs file.

If this method works, I think all raster saving methods in the system can use this method.