### PR TITLE
Upgrade packages that have a dependence to a vulnerable version of NewtonSoft.Json

### DIFF
--- a/Source/Tests/DotSpatial.Analysis.Tests/DotSpatial.Analysis.Tests.csproj
+++ b/Source/Tests/DotSpatial.Analysis.Tests/DotSpatial.Analysis.Tests.csproj
@@ -8,10 +8,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Tests/DotSpatial.Controls.Tests/DotSpatial.Controls.Tests.csproj
+++ b/Source/Tests/DotSpatial.Controls.Tests/DotSpatial.Controls.Tests.csproj
@@ -8,10 +8,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Tests/DotSpatial.Data.Tests/DotSpatial.Data.Tests.csproj
+++ b/Source/Tests/DotSpatial.Data.Tests/DotSpatial.Data.Tests.csproj
@@ -8,11 +8,14 @@
 
 	<ItemGroup>		
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NetTopologySuite" Version="2.4.0" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="GDAL.Native" Version="3.4.1" />
 	</ItemGroup>
 

--- a/Source/Tests/DotSpatial.NTSExtension.Tests/DotSpatial.NTSExtension.Tests.csproj
+++ b/Source/Tests/DotSpatial.NTSExtension.Tests/DotSpatial.NTSExtension.Tests.csproj
@@ -9,10 +9,13 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Tests/DotSpatial.Positioning.Tests/DotSpatial.Positioning.Tests.csproj
+++ b/Source/Tests/DotSpatial.Positioning.Tests/DotSpatial.Positioning.Tests.csproj
@@ -8,10 +8,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Tests/DotSpatial.Projections.Tests/DotSpatial.Projections.Tests.csproj
+++ b/Source/Tests/DotSpatial.Projections.Tests/DotSpatial.Projections.Tests.csproj
@@ -8,10 +8,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Tests/DotSpatial.Serialization.Tests/DotSpatial.Serialization.Tests.csproj
+++ b/Source/Tests/DotSpatial.Serialization.Tests/DotSpatial.Serialization.Tests.csproj
@@ -8,10 +8,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Tests/DotSpatial.Symbology.Tests/DotSpatial.Symbology.Tests.csproj
+++ b/Source/Tests/DotSpatial.Symbology.Tests/DotSpatial.Symbology.Tests.csproj
@@ -8,10 +8,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Tests/DotSpatial.Tests.Common/DotSpatial.Tests.Common.csproj
+++ b/Source/Tests/DotSpatial.Tests.Common/DotSpatial.Tests.Common.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Tests/DotSpatial.Tools.Tests/DotSpatial.Tools.Tests.csproj
+++ b/Source/Tests/DotSpatial.Tools.Tests/DotSpatial.Tools.Tests.csproj
@@ -8,10 +8,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="GDAL.Native" Version="3.4.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
there is a issue in versions prior to 13.0.2 concerning default mx depth causing stack overflow exception and them a DOS.

https://github.com/JamesNK/Newtonsoft.Json/issues/2457
https://github.com/JamesNK/Newtonsoft.Json/pull/2462

### Checklist

- [x ] I have included examples or tests
- [x ] I have updated the change log
- [x ] I am listed in the CONTRIBUTORS file
- [x ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Update packages that have a dependence to vulnerable version of Newtonsoft.Json