### PR TITLE
Selection issue if LabelLayer is present and EditMode=true (#1519)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Shorten column names to max 10 characters on writing to dbf file (#1494)
 - DotSpatial.Plugins.Taudem/Hydrology.cs RunTaudem function does not execute correctly (#1496) 
 - Taudem set stream shape prj file (#1501)
+- Selection issue if LabelLayer is present and EditMode=true (#1519)
 
 ## V4.0
 

--- a/Source/Core/DotSpatial.Controls/MapLabelLayer.cs
+++ b/Source/Core/DotSpatial.Controls/MapLabelLayer.cs
@@ -1155,7 +1155,7 @@ namespace DotSpatial.Controls
 
                 for (int i = 0; i < catFeatures.Count; i++)
                 {
-                    if (!FeatureLayer.DrawnStates[i].Visible)
+                    if (!FeatureLayer.GetVisible(i))
                     {
                         continue;
                     }


### PR DESCRIPTION
Fixes #1519.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
For programmatically created layers (with EditMode=true), the feature selection by attribute does not work, if a LabelLayer is present.
