### PR TITLE
change LangVersion to 10 and use TargetFrameworks for .netStarndard2.0 projects

### DIFF
--- a/Source/Core/DotSpatial.Data/DotSpatial.Data.csproj
+++ b/Source/Core/DotSpatial.Data/DotSpatial.Data.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <LangVersion>9.0</LangVersion>
-      <TargetFramework>netstandard2.0</TargetFramework>
+	  <TargetFrameworks>netstandard2.0</TargetFrameworks>
+	  <LangVersion>10.0</LangVersion>
       <Description>GIS Data objects for DotSpatial.</Description>
   </PropertyGroup>
 

--- a/Source/Core/DotSpatial.Extensions/DotSpatial.Extensions.csproj
+++ b/Source/Core/DotSpatial.Extensions/DotSpatial.Extensions.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <LangVersion>9.0</LangVersion>
-      <TargetFramework>netstandard2.0</TargetFramework>
+	  <TargetFrameworks>netstandard2.0</TargetFrameworks>
+	  <LangVersion>10.0</LangVersion>
     <Description>Interfaces which allow DotSpatial to be extended.</Description>
   </PropertyGroup>
 

--- a/Source/Core/DotSpatial.NTSExtension/DotSpatial.NTSExtension.csproj
+++ b/Source/Core/DotSpatial.NTSExtension/DotSpatial.NTSExtension.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+	  <TargetFrameworks>netstandard2.0</TargetFrameworks>
+	  <LangVersion>10.0</LangVersion>
     <Description>NTS extensions for DotSpatial.</Description>
   </PropertyGroup>
 

--- a/Source/Core/DotSpatial.Positioning.Design/DotSpatial.Positioning.Design.csproj
+++ b/Source/Core/DotSpatial.Positioning.Design/DotSpatial.Positioning.Design.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+	  <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+	  <LangVersion>10.0</LangVersion>
     <Description>This assembly provides objects used to design geographic applications.</Description>
   </PropertyGroup>
 

--- a/Source/Core/DotSpatial.Serialization/DotSpatial.Serialization.csproj
+++ b/Source/Core/DotSpatial.Serialization/DotSpatial.Serialization.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <LangVersion>9.0</LangVersion>
-      <TargetFramework>netstandard2.0</TargetFramework>
+	  <TargetFrameworks>netstandard2.0</TargetFrameworks>
+	  <LangVersion>10.0</LangVersion>
     <Description>Helper assembly to save DotSpatial objects to file.</Description>
   </PropertyGroup>
 

--- a/Source/Core/DotSpatial.Symbology/DotSpatial.Symbology.csproj
+++ b/Source/Core/DotSpatial.Symbology/DotSpatial.Symbology.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+	  <TargetFrameworks>netstandard2.0</TargetFrameworks>
+	  <LangVersion>10.0</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <Description>Customize map cartographic symbols.</Description>
   </PropertyGroup>


### PR DESCRIPTION
NuGet Packages for DotSpatial.Data, DotSpatial.Serialisation are only available for .net6, but nuget package for DotSpatial.Projections .netStandard2.0 is available.

This was the only difference I could find for the packages.

### Changes proposed in this pull request:

- Changed Target Framework to TargetFrameworks and Langversion to 10 for .netStandard2.0 Projects